### PR TITLE
Add Claude Code delegation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Plugins add tools and skills through a sandboxed marketplace; MCP servers add ex
 | **Tools** | 30 core tools covering search, browser, shell, filesystem, documents, Gmail, Calendar, X, memory, workflows, tracker, image/video, vision, status, MCP, updates, computation, weather, charts, and system info |
 | **Automation** | Scheduled workflows, step pipelines, conditions, approvals, subtasks, webhooks, task-completion triggers, notifications, channel delivery, run history, and safety modes |
 | **Channels & Voice** | Telegram, WhatsApp, Discord, Slack, SMS, local faster-whisper STT, Kokoro TTS, media intake, reactions, streaming, approval routing, and tunnel manager |
-| **Platform & Extensibility** | Native desktop app, one-click installers, auto-updates, plugin marketplace, MCP client, migration wizard, configurable identity, secure API-key storage, 12 manual skills, and 18 tool guides |
+| **Platform & Extensibility** | Native desktop app, one-click installers, auto-updates, plugin marketplace, MCP client, migration wizard, configurable identity, secure API-key storage, 13 manual skills, and 18 tool guides |
 
 [Detailed architecture and subsystem reference →](docs/ARCHITECTURE.md)
 

--- a/bundled_skills/claude_code_delegation/SKILL.md
+++ b/bundled_skills/claude_code_delegation/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: claude_code_delegation
+display_name: Claude Code Delegation
+icon: "💻"
+description: Delegate coding, review, and refactor tasks to Claude Code CLI through Thoth's approval-gated shell workflow.
+enabled_by_default: false
+version: "1.0"
+tags:
+  - coding
+  - claude
+  - delegation
+  - review
+  - automation
+author: Thoth
+---
+
+When the user asks to **use Claude Code**, **coordinate Claude Code**, **delegate coding work**, **have another coding agent implement/review/refactor something**, or compares Thoth with Hermes-style Claude Code orchestration, use this workflow.
+
+You are the coordinator. Claude Code is the delegated coding worker. Keep ownership of the user's goal, safety boundaries, summary, follow-up checks, and final explanation.
+
+## Core Principles
+
+1. **Prefer print mode first** — Use `claude -p` for most tasks. It runs one bounded task, returns output, and exits. This works well with Thoth's `run_command` tool and avoids interactive terminal state.
+2. **Keep Thoth in charge** — Do not hand off the whole conversation. Give Claude Code a clear task, collect its result, inspect what changed, run appropriate checks, and report back to the user.
+3. **Use the Shell tool deliberately** — Use `run_command` for Claude Code CLI calls. Thoth's shell tool persists the working directory per conversation and approval-gates non-safe commands.
+4. **Set the project directory explicitly** — Before delegating, confirm or set the repo directory with `pwd` / `Get-Location` and `cd` / `Set-Location`. Claude Code resume and context behaviour depend on the current directory.
+5. **Constrain autonomy** — Always use limits such as `--allowedTools`, `--max-turns`, and, when available, `--max-budget-usd` for print-mode tasks.
+6. **Avoid permission bypass** — Do not use `--dangerously-skip-permissions` unless the user explicitly asks and understands that Claude Code may edit files and run commands without per-action prompts.
+7. **Do not forward secrets** — Never include API keys, tokens, Thoth memory, private notes, or sensitive user data in a Claude Code prompt unless the user explicitly asks for that specific context to be shared.
+
+## Prerequisite Checks
+
+Before the first delegation in a project or session, check whether Claude Code is available and authenticated:
+
+```text
+claude --version
+claude auth status
+claude doctor
+```
+
+If these fail, explain the setup path briefly:
+
+```text
+npm install -g @anthropic-ai/claude-code
+claude auth login
+```
+
+On Windows, native print-mode CLI usage may work if `claude` is installed on PATH. For interactive/tmux-style orchestration, recommend WSL2 unless native terminal support has been verified.
+
+## Delegation Workflow
+
+1. **Understand the task** — Restate the requested coding outcome, target repo/path, and expected verification. Ask one clarifying question only if the target or risk level is unclear.
+2. **Inspect local state first** — Use safe shell commands such as `git status`, `git diff`, and directory listing commands before delegation. Notice uncommitted user changes and do not overwrite them.
+3. **Choose capability scope** — Pick the narrowest Claude Code tool set for the task:
+   - Review/explain only: `--allowedTools "Read"`
+   - Edit existing files: `--allowedTools "Read,Edit"`
+   - Create files/tests: `--allowedTools "Read,Edit,Write"`
+   - Run tests/builds: `--allowedTools "Read,Edit,Write,Bash"`
+4. **Ask for approval when needed** — A Claude Code run that can edit files or run shell commands is write-capable delegation. If the user did not already authorize that, confirm before running it.
+5. **Run Claude Code in print mode** — Use a bounded command with a concise prompt, explicit limits, and JSON output when useful.
+6. **Inspect the result** — After Claude Code exits, run `git status` and inspect the diff. Do not assume the delegated agent did the right thing.
+7. **Verify** — Run targeted tests, lint, type checks, or smoke checks appropriate to the change. If verification is expensive or unclear, ask before running broad suites.
+8. **Report clearly** — Summarize what Claude Code changed, what you verified, any failures or uncertainties, and recommended next steps.
+
+## Print-Mode Command Patterns
+
+Use these as patterns, adapting quoting for the user's shell. In Thoth, it is often cleaner to set the directory first, then run `claude` as a separate command so the shell session cwd persists.
+
+### Status and Setup
+
+```text
+claude --version
+claude auth status
+claude doctor
+```
+
+### Read-Only Review
+
+```text
+claude -p "Review the current repository changes for bugs, security issues, and missing tests. Do not edit files. Return findings with file paths and verification suggestions." --allowedTools "Read" --max-turns 3 --output-format json
+```
+
+### Focused Edit
+
+```text
+claude -p "Implement the requested fix in the smallest safe change. Preserve existing style. After editing, summarize changed files and tests to run." --allowedTools "Read,Edit" --max-turns 8 --max-budget-usd 2 --output-format json
+```
+
+### Feature Work With Tests
+
+```text
+claude -p "Implement this feature and add focused tests. Prefer minimal, idiomatic changes. Run the relevant tests if safe. Return a summary, files changed, tests run, and any remaining risks." --allowedTools "Read,Edit,Write,Bash" --max-turns 12 --max-budget-usd 4 --output-format json
+```
+
+### Diff Review
+
+```text
+git diff --stat
+git diff | claude -p "Review this diff for correctness, regressions, security issues, and missing tests. Do not edit files." --allowedTools "Read" --max-turns 1
+```
+
+If the diff is large, save a focused patch file for Claude Code to inspect, but avoid including secrets or unrelated local changes. Remember that Claude Code cannot see Thoth's previous tool output unless you pass the relevant context into the Claude Code prompt, stdin, files, or repository state.
+
+## Prompt Construction
+
+Give Claude Code a compact brief:
+
+```text
+Goal: <specific outcome>
+Repo/path: <current directory or subpath>
+Constraints: preserve user changes, follow existing patterns, avoid broad refactors
+Allowed work: <read-only | edit existing files | create tests | run tests>
+Verification: <specific commands or ask it to identify tests>
+Output: summary, files changed, tests run, remaining risks
+```
+
+Do not ask Claude Code to make commits, push branches, publish releases, delete data, rotate secrets, or run production-affecting commands unless the user explicitly requested that operation.
+
+## Session Continuation
+
+When using `--output-format json`, capture the returned `session_id` if Claude Code provides one. Use resume only when continuing the same task in the same project directory:
+
+```text
+claude -p "Continue from the previous session and address the remaining test failure." --resume <session_id> --max-turns 5 --allowedTools "Read,Edit,Bash"
+```
+
+Use `--continue` only when you are sure the most recent Claude Code session in the current directory is the one you want. If unsure, start a fresh print-mode task instead.
+
+## Worktree Mode
+
+For larger or risky edits, prefer isolating Claude Code's work in a branch or worktree when available:
+
+```text
+claude -p "Implement the feature in an isolated worktree and summarize the diff." --worktree thoth-delegation-task --allowedTools "Read,Edit,Write,Bash" --max-turns 12 --max-budget-usd 4
+```
+
+Afterward, inspect the worktree diff before merging or copying changes back. Do not merge or delete worktrees without user approval.
+
+## Interactive Mode Is Advanced
+
+Interactive Claude Code is useful for long, multi-turn coding sessions, Claude Code slash commands, and human-in-the-loop exploration. It is also more fragile.
+
+Use interactive mode only when print mode is insufficient. Prefer macOS/Linux/WSL2 with `tmux` for reliable monitoring:
+
+```text
+tmux new-session -d -s claude-work -x 140 -y 40
+tmux send-keys -t claude-work 'cd /path/to/project; claude' Enter
+tmux capture-pane -t claude-work -p -S -50
+tmux send-keys -t claude-work 'Now add focused regression tests' Enter
+tmux send-keys -t claude-work '/exit' Enter
+tmux kill-session -t claude-work
+```
+
+Rules for interactive mode:
+
+- Prefer WSL2 on Windows for tmux-based orchestration.
+- Monitor with `tmux capture-pane` before assuming the session is stuck.
+- Look for a prompt or clear waiting state before sending follow-up input.
+- Clean up tmux sessions when done.
+- Do not leave background coding agents running silently.
+
+## Safety Boundaries
+
+- Treat Claude Code as a powerful external actor that can edit the repo and spend API quota.
+- Use `--allowedTools` every time.
+- Use `--max-turns` for print mode every time.
+- Use `--max-budget-usd` for non-trivial tasks when available.
+- Avoid broad filesystem access with `--add-dir` unless required.
+- Avoid `--permission-mode bypassPermissions` and `--dangerously-skip-permissions` by default.
+- Do not run destructive git commands, force pushes, deploys, production migrations, or secret-handling tasks through Claude Code without explicit user approval.
+- Respect Thoth background workflow safety modes: write-capable Claude Code runs should not happen in unattended background tasks unless the user selected an approval or allow-all mode for that task.
+
+## After Delegation
+
+Always follow up with Thoth-native review:
+
+1. Run `git status`.
+2. Inspect changed files or the diff.
+3. Run relevant tests/checks if appropriate.
+4. Tell the user:
+   - what Claude Code attempted,
+   - what changed,
+   - what passed or failed,
+   - what still needs human review.
+
+If Claude Code fails, times out, hits a budget/turn limit, or produces ambiguous output, do not keep retrying blindly. Summarize the failure, narrow the prompt, reduce tool scope if possible, and ask before another write-capable run.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -672,11 +672,12 @@ A sandboxed, hot-reloadable extension system lets plugins add new tools and skil
 
 Skills are reusable instruction packs that shape how the agent thinks and responds. Each skill is a `SKILL.md` file with YAML frontmatter (display name, icon, description, required tools, tags) and freeform instructions injected into the system prompt when enabled.
 
-Thoth ships with **12 manual bundled skills** and **18 tool guides**. Manual skills are toggled from Settings; tool guides auto-activate when their linked tools are available.
+Thoth ships with **13 manual bundled skills** and **18 tool guides**. Manual skills are toggled from Settings; tool guides auto-activate when their linked tools are available.
 
 | Skill | Description |
 |-------|-------------|
 | **🧠 Brain Dump** | Capture unstructured thoughts and organize them into structured notes saved to memory |
+| **💻 Claude Code Delegation** | Coordinate Claude Code CLI as an external coding agent through Thoth's approval-gated shell workflow |
 | **☀️ Daily Briefing** | Compile a morning briefing with weather, calendar, and news headlines |
 | **📊 Data Analyst** | Analyze datasets, produce statistical summaries, and create insightful charts |
 | **🔬 Deep Research** | Perform multi-source research on a topic and produce a structured report |
@@ -725,7 +726,7 @@ Thoth ships with **12 manual bundled skills** and **18 tool guides**. Manual ski
 | **`prompts.py`** | Centralized prompt templates including summarization, extraction, and dream-insights analysis |
 | **`memory_extraction.py`** | Background conversation scan that extracts entities and relations the live agent did not save |
 | **`skills.py`** | Discovery, loading, activation, override, and prompt-building for manual skills and tool guides |
-| **`bundled_skills/`** | 12 built-in manual skills as `SKILL.md` packages |
+| **`bundled_skills/`** | 13 built-in manual skills as `SKILL.md` packages |
 | **`tool_guides/`** | 18 built-in tool-specific auto-activation guides |
 | **`tasks.py`** | Workflow engine, SQLite persistence, APScheduler scheduling, pipeline execution, run history, safety mode, and delivery routing |
 | **`notifications.py`** | Unified desktop, sound, and toast notification system |

--- a/docs/index.html
+++ b/docs/index.html
@@ -982,7 +982,7 @@
         </div>
         <div class="hero-meta">
             <span data-count="30" data-prefix="" data-suffix=" core tools">0 core tools</span>
-            <span data-count="12" data-prefix="" data-suffix=" bundled skills">0 bundled skills</span>
+            <span data-count="13" data-prefix="" data-suffix=" bundled skills">0 bundled skills</span>
             <span data-count="39" data-prefix="" data-suffix=" local models">0 local models</span>
             <span>Apache 2.0 &middot; Free</span>
         </div>

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -2266,6 +2266,7 @@ def section_16_skills():
                 names.add(sk.name)
         expected = {
             "daily_briefing", "deep_research", "meeting_notes", "brain_dump",
+            "claude_code_delegation",
             "task_automation", "humanizer", "self_reflection",
             "proactive_agent", "web_navigator",
         }
@@ -2301,6 +2302,11 @@ def section_16_skills():
         est_explicit = skills.estimate_tokens(["daily_briefing", "deep_research", "brain_dump"])
         assert est_global == est_explicit, \
             f"global={est_global} vs explicit={est_explicit}"
+        est_skill_only = skills.estimate_skill_tokens("daily_briefing")
+        assert est_skill_only == skills.estimate_text_tokens(
+            skills.get_skill("daily_briefing").instructions
+        )
+        assert est_skill_only <= skills.estimate_tokens(["daily_briefing"])
 
         # Restore original enabled state
         for _name, _was_enabled in _orig_enabled.items():

--- a/skills.py
+++ b/skills.py
@@ -342,6 +342,25 @@ def estimate_tokens(skill_names: Optional[list[str]] = None) -> int:
     return len(text) // 4 if text else 0
 
 
+def estimate_text_tokens(text: str) -> int:
+    """Rough token estimate for arbitrary skill text (~4 chars per token)."""
+    return len(text or "") // 4
+
+
+def estimate_skill_tokens(name: str) -> int:
+    """Rough token estimate for one skill's own instructions.
+
+    This intentionally excludes auto-active tool guides and shared prompt
+    wrapper text. Use ``estimate_tokens`` when estimating the complete injected
+    skills prompt for an enabled skill set.
+    """
+    _ensure_skills_loaded()
+    skill = _skills_cache.get(name)
+    if not skill:
+        return 0
+    return estimate_text_tokens(skill.instructions)
+
+
 # ── Skill CRUD ───────────────────────────────────────────────────────────────
 
 

--- a/test_suite.py
+++ b/test_suite.py
@@ -5366,6 +5366,7 @@ try:
         assert len(_discovered) >= 8, f"expected ≥8 bundled skills, got {len(_discovered)}"
         _expected_names = {
             "daily_briefing", "deep_research", "meeting_notes", "brain_dump",
+            "claude_code_delegation",
             "task_automation", "humanizer", "self_reflection",
             "proactive_agent", "web_navigator",
         }
@@ -5712,6 +5713,11 @@ try:
     _est_one = _skills_mod36.estimate_tokens(["daily_briefing"])
     assert _est_one > 0
     assert _est_names > _est_one, "2 skills should estimate more than 1"
+    _skill_only_est = _skills_mod36.estimate_skill_tokens("daily_briefing")
+    assert _skill_only_est == _skills_mod36.estimate_text_tokens(
+        _skills_mod36.get_skill("daily_briefing").instructions
+    ), "single-skill estimate should count only that skill's instructions"
+    assert _skill_only_est <= _est_one, "single-skill estimate should not include shared prompt or tool guides"
     record("PASS", "skills: estimate_tokens with explicit names")
 
     # ── 36ah. Config corruption recovery ─────────────────────────────

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -931,11 +931,11 @@ def open_settings(
                                 ui.badge("Bundled", color="blue-grey").props("outline")
                             else:
                                 ui.badge("Custom", color="teal").props("outline")
-                            tokens = skills_mod.estimate_tokens([sk.name])
+                            tokens = skills_mod.estimate_skill_tokens(sk.name)
                             if tokens > 0:
                                 ui.badge(f"~{tokens} tokens", color="orange").props(
                                     "outline"
-                                ).tooltip("Approximate tokens added to context when enabled")
+                                ).tooltip("Approximate tokens in this skill's instructions")
                         ui.label(sk.description).classes("text-grey-6 text-sm q-pl-lg")
 
                         with ui.row().classes("q-pl-lg q-mt-xs gap-1"):
@@ -1011,7 +1011,7 @@ def open_settings(
 
                 def _update_token_est():
                     txt = instructions_input.value or ""
-                    est = len(txt) // 4
+                    est = skills_mod.estimate_text_tokens(txt)
                     token_label.text = f"~{est} tokens"
 
                 with ui.row().classes("w-full items-center"):


### PR DESCRIPTION
Add a bundled Claude Code delegation skill, update bundled skill counts and tests, and fix per-skill token estimates in Settings.

## Summary

Describe what changed and why.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [x] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `python test_suite.py`
- [ ] I added or updated tests
- [ ] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [x] User-visible change, release notes needed
- [ ] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [ ] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [ ] Windows/macOS behavior considered where relevant
