### PR TITLE
Add custom endpoint option to setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Thoth's agent has access to 30 core tool modules. Many of them expose multiple o
 
 > **Works on Apple Silicon (M1/M2/M3/M4) and Intel Macs** (macOS 12+). No terminal, no manual setup — just double-click and go.
 
-> **Using provider models only?** The installer still sets up Ollama by default, but you can skip model downloads. On first launch, choose the **Providers** setup path, enter your API key, and start chatting — no GPU required.
+> **Using provider or custom endpoint models only?** The installer still sets up Ollama by default, but you can skip model downloads. On first launch, choose **Providers** for API-key models or **Custom/Self-hosted** for an OpenAI-compatible endpoint such as LM Studio.
 
 ---
 
@@ -316,7 +316,7 @@ Thoth's agent has access to 30 core tool modules. Many of them expose multiple o
    python app.py
    ```
 
-> **First launch:** A setup wizard lets you choose between **Local** (Ollama) and **Providers** (API key) setup paths. For local, the default brain model (`qwen3:14b`, ~9 GB) is recommended. For Providers, enter your API key (OpenAI, Anthropic, Google AI, xAI, or OpenRouter), pick a default model, and seed Quick Choices for everyday pickers. ChatGPT / Codex sign-in is available after launch in **Settings → Providers**.
+> **First launch:** A setup wizard lets you choose between **Local** (Ollama), **Providers** (API key), and **Custom/Self-hosted** setup paths. For local, the default brain model (`qwen3:14b`, ~9 GB) is recommended. For Providers, enter your API key (OpenAI, Anthropic, Google AI, xAI, or OpenRouter), pick a default model, and seed Quick Choices for everyday pickers. For Custom/Self-hosted, enter an OpenAI-compatible base URL such as LM Studio's `http://127.0.0.1:1234/v1`, leave the API key blank for no-auth local servers, fetch models, and pick a default. ChatGPT / Codex sign-in is available after launch in **Settings → Providers**.
 
 ---
 
@@ -392,13 +392,23 @@ For **Gmail** and **Google Calendar**, you'll need a Google Cloud OAuth `credent
 4. Optional: open **Settings → Providers** to sign in to ChatGPT / Codex for subscription-backed Codex models
 5. Switch models per conversation anytime from the chat header dropdown; raw provider catalogs and pinning live in **Settings → Models**
 
+### Custom/Self-hosted Models
+
+1. Start your OpenAI-compatible server, such as LM Studio, vLLM, LocalAI, or a private gateway
+2. On the setup wizard, choose **Custom/Self-hosted**
+3. Enter the base URL, for example `http://127.0.0.1:1234/v1` for LM Studio's local server
+4. Leave the API key blank for no-auth local servers, or enter the key required by your gateway
+5. Click **Connect & Fetch Models**, choose the model Thoth should use by default, then finish setup
+
+For LM Studio, load the model with a context window large enough for Thoth's agent prompt and enabled tool schemas. A `4096` context can fail before the first chat turn with a misleading prompt-template error such as `No user query found in messages`; `32768` is a practical starting point for normal agent use.
+
 ---
 
 ## 🔒 Privacy & Security — Personal AI Sovereignty
 
 **Local models (default):** All LLM inference runs on your machine via Ollama. Documents, memories, and conversations stored locally in `~/.thoth/`. External network calls only when using online tools (web search, Gmail, Calendar) — each individually disableable. No telemetry, no tracking.
 
-**Provider models (opt-in):** The current conversation plus model-visible tool context and tool results are sent to the selected LLM provider (OpenAI, Anthropic, Google AI, xAI, OpenRouter, or ChatGPT / Codex). Memories, knowledge graph, documents, files, and other conversations never leave your machine unless you explicitly include them in the active conversation or expose them through a tool result. API-key providers connect directly to the provider; ChatGPT / Codex uses your in-app ChatGPT sign-in and ChatGPT subscription/internal Codex backend. Thoth has no servers and no middleman.
+**Provider and custom models (opt-in):** The current conversation plus model-visible tool context and tool results are sent to the selected model endpoint (OpenAI, Anthropic, Google AI, xAI, OpenRouter, ChatGPT / Codex, or your configured OpenAI-compatible custom endpoint). Memories, knowledge graph, documents, files, and other conversations never leave your machine unless you explicitly include them in the active conversation or expose them through a tool result. API-key providers connect directly to the provider; ChatGPT / Codex uses your in-app ChatGPT sign-in and ChatGPT subscription/internal Codex backend; custom endpoints connect directly to the base URL you configure. Thoth has no servers and no middleman.
 
 **Always:** Core and plugin API keys are stored locally in your OS credential store when available, with only masked metadata in Thoth's data folder. No Thoth account required; no sign-up; no server to phone home to. Tools can be individually disabled to control what the agent can access.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,7 +24,7 @@ This release also adds **ChatGPT / Codex** as a distinct subscription-backed pro
 - **Models tab ownership** — model browsing, raw provider catalogs, local Ollama catalog rows, pin/unpin actions, defaults, and Quick Choices now live in **Settings → Models**
 - **Consolidated Model Catalog** — a category-first catalog groups Brain, Vision, Image, and Video-capable rows by provider, with inline actions for pinning, setting defaults, downloading local models, and clearing disabled reasons
 - **Polished Defaults panel** — Brain, Vision, Image, and Video defaults use compact provider/local badges, context controls, enable switches, and empty states that point users to the catalog instead of scattering model controls across tabs
-- **First-run setup alignment** — setup now offers migration before model setup, supports the Providers path for API-key users, and points users to Settings → Models for exact model pinning after launch
+- **First-run setup alignment** — setup now offers migration before model setup, supports Providers for API-key users plus Custom/Self-hosted OpenAI-compatible endpoints such as LM Studio, and points users to Settings → Models for exact model pinning after launch
 
 ### 💬 Picker Unification
 
@@ -81,6 +81,7 @@ This release also adds **ChatGPT / Codex** as a distinct subscription-backed pro
 - **Subscription backend risk** — ChatGPT / Codex uses ChatGPT's subscription/internal Codex backend rather than the public OpenAI API. The endpoint, catalog shape, auth requirements, rate limits, and model availability may change upstream without the same stability guarantees as the public API
 - **Privacy** — when a ChatGPT / Codex model is selected, the current conversation plus model-visible tool context and tool results are sent to ChatGPT / Codex for that turn. Durable Thoth data such as memories, documents, files, and other conversations stay local unless explicitly included in the active conversation or exposed through a tool result
 - **Manual smoke still required** — before publishing installers, run clean-machine Windows/macOS smoke for first launch, Settings → Providers, Settings → Models catalog/pinning/defaults, ChatGPT / Codex sign-in/status, shared model pickers, and a long Designer/browser task with reconnect
+- **LM Studio custom endpoint smoke** — when testing LM Studio through the Custom/Self-hosted setup path, load the selected model with enough context for Thoth's agent prompt and enabled tool schemas. A `4096` context can fail with a misleading prompt-template error such as `No user query found in messages`; `32768` is a practical smoke-test baseline.
 
 ### 📁 Files Changed
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -147,7 +147,7 @@ The brain model is Thoth's default LLM — the model used for conversations, mem
 
 Thoth is built and tested for local models first. Every feature supports local models, and that remains the priority. Local models already handle tool calling, multi-step reasoning, memory extraction, and long conversations well with a 14B+ model.
 
-Provider models are supported for users without a dedicated GPU, for frontier reasoning on demand, or for trying many providers without downloading large local weights. Thoth supports opt-in provider models through **OpenAI** (direct API), **Anthropic** (Claude), **Google AI** (Gemini), **xAI** (Grok), **OpenRouter** (many third-party models), and **ChatGPT / Codex** (subscription-backed Codex models). Provider connections, health, and credential sources are configured from Settings -> Providers; model catalog browsing, pinning, and defaults live in Settings -> Models.
+Provider models are supported for users without a dedicated GPU, for frontier reasoning on demand, or for trying many providers without downloading large local weights. Thoth supports opt-in provider models through **OpenAI** (direct API), **Anthropic** (Claude), **Google AI** (Gemini), **xAI** (Grok), **OpenRouter** (many third-party models), **ChatGPT / Codex** (subscription-backed Codex models), and Custom/Self-hosted OpenAI-compatible endpoints such as LM Studio, vLLM, LocalAI, or private gateways. Provider connections, health, and credential sources are configured from Settings -> Providers; model catalog browsing, pinning, and defaults live in Settings -> Models.
 
 The `providers/` subsystem now owns provider config, auth metadata, model catalog normalization, runtime construction, display-safe status, and Quick Choices. Existing public functions in `models.py` remain as compatibility facades while provider-backed selection is rolled through the app.
 
@@ -642,7 +642,7 @@ A sandboxed, hot-reloadable extension system lets plugins add new tools and skil
 - **Native window** — runs in a desktop window via pywebview rather than depending on a browser tab
 - **System tray** — `launcher.py` exposes open and quit controls plus running-state feedback
 - **Splash screen** — Tk-based splash with console fallback during startup
-- **First-launch setup wizard** — guides the user through migration, Local, or Providers setup paths without touching config files
+- **First-launch setup wizard** — guides the user through migration, Local, Providers, or Custom/Self-hosted setup paths without touching config files
 - **Self-contained installers** — Windows and macOS releases bundle dependencies for one-click setup
 - **Auto-restart flow** — closing the native window does not kill the tray-managed app process; reopen is fast
 - **Release pipeline** — build, sign, notarize, and publish automation lives in CI

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,7 +43,8 @@ Thoth uses semantic versioning:
    Windows `installer/thoth_setup.iss`, macOS `installer/build_mac_app.sh`,
    and the installer payload notes in `installer/README.md`.
 7. Smoke-test first-run behavior against a clean data directory before building
-   artifacts, especially setup wizard imports and provider config defaults.
+   artifacts, especially setup wizard imports, provider config defaults, and
+   Custom/Self-hosted endpoint setup.
 8. Open and merge the release-prep PR.
 
 ## Build artifacts

--- a/installer/README.md
+++ b/installer/README.md
@@ -173,12 +173,13 @@ The Inno Setup installer runs these steps:
 2. Follow the wizard — dependencies download and install automatically (5-15 min)
 3. Launch Thoth from Start Menu or Desktop shortcut
 4. The system tray icon appears; the app opens at `http://localhost:8080`
-5. First launch shows a setup wizard — choose **Local** (download an Ollama model) or **Providers** (enter an API key and pick a provider model)
+5. First launch shows a setup wizard — choose **Local** (download an Ollama model), **Providers** (enter an API key and pick a provider model), or **Custom/Self-hosted** (enter an OpenAI-compatible endpoint such as LM Studio, fetch models, and pick a default)
 
 ## Notes
 
 - **CPU-only PyTorch**: `requirements.txt` uses CPU-only torch. Users with NVIDIA GPUs can upgrade to CUDA torch after install.
 - **Ollama is optional**: `install_deps.bat` offers to install Ollama, but it can be skipped for provider-only setups. Thoth works with API-key provider models (OpenAI, Anthropic, Google AI, xAI, OpenRouter) and ChatGPT / Codex subscription models after in-app ChatGPT sign-in.
+- **Custom/self-hosted endpoints**: first-run setup can connect to OpenAI-compatible endpoints such as LM Studio, vLLM, LocalAI, or private gateways. LM Studio's local server commonly uses `http://127.0.0.1:1234/v1`; load the selected model with a larger context window, such as `32768`, so Thoth's agent prompt and enabled tools fit.
 - **Codex credential boundary**: external Codex CLI auth files are metadata/reference only. Direct ChatGPT / Codex runtime in the packaged app requires the in-app ChatGPT sign-in and stores Thoth-owned tokens in the OS credential store.
 - **Launcher**: Uses `launcher.py` (system tray icon + native window + splash screen) instead of running NiceGUI directly. The tray icon shows app status (running/stopped) and provides graceful shutdown.
 - **Uninstall**: Registered with Windows Add/Remove Programs. The uninstaller removes the installation directory but does **not** delete user data in `~/.thoth/` — users can remove it manually if desired.

--- a/test_setup_wizard_custom.py
+++ b/test_setup_wizard_custom.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from providers.models import ModelInfo, TransportMode
+from ui.setup_wizard import build_custom_endpoint_setup_payload, custom_endpoint_model_options
+
+
+def test_custom_endpoint_setup_payload_uses_api_key_auth() -> None:
+    payload = build_custom_endpoint_setup_payload("http://127.0.0.1:8000/v1/", " sk-local ")
+
+    assert payload["id"] == "127.0.0.1:8000"
+    assert payload["name"] == "Self-hosted (127.0.0.1:8000)"
+    assert payload["base_url"] == "http://127.0.0.1:8000/v1"
+    assert payload["api_key"] == "sk-local"
+    assert payload["auth_required"] is True
+    assert payload["execution_location"] == "local"
+    assert payload["transport"] == "openai_chat"
+
+
+def test_custom_endpoint_setup_payload_treats_empty_key_as_no_auth() -> None:
+    payload = build_custom_endpoint_setup_payload("https://models.example.com/v1", "")
+
+    assert payload["id"] == "models.example.com"
+    assert payload["api_key"] == ""
+    assert payload["auth_required"] is False
+    assert payload["execution_location"] == "remote"
+
+
+def test_custom_endpoint_model_options_use_provider_model_refs() -> None:
+    info = ModelInfo(
+        provider_id="custom_openai_localai",
+        model_id="thoth-dummy-chat",
+        display_name="Thoth Dummy Chat",
+        context_window=4096,
+        transport=TransportMode.OPENAI_CHAT,
+    )
+
+    assert custom_endpoint_model_options([info]) == {
+        "model:custom_openai_localai:thoth-dummy-chat": "↔ Thoth Dummy Chat"
+    }

--- a/test_suite.py
+++ b/test_suite.py
@@ -13975,6 +13975,7 @@ try:
         "test_provider_runtime.py",
         "test_provider_selection.py",
         "test_provider_subscription_auth.py",
+        "test_setup_wizard_custom.py",
         "test_thoth_status_media.py",
         "integration_tests.py",
     }

--- a/ui/setup_wizard.py
+++ b/ui/setup_wizard.py
@@ -12,15 +12,61 @@ The wizard is self-contained except for two callbacks:
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import sys
 from typing import Callable
+from urllib.parse import urlparse
 
 from nicegui import run, ui
 
 from ui.state import AppState
 
 logger = logging.getLogger(__name__)
+
+
+def _custom_endpoint_host_label(base_url: str) -> str:
+    parsed = urlparse(base_url if "://" in str(base_url) else f"http://{base_url}")
+    host = parsed.hostname or str(base_url or "").strip().rstrip("/")
+    if parsed.port and parsed.hostname:
+        return f"{parsed.hostname}:{parsed.port}"
+    return host or "endpoint"
+
+
+def _custom_endpoint_execution_location(base_url: str) -> str:
+    host = urlparse(base_url if "://" in str(base_url) else f"http://{base_url}").hostname or ""
+    normalized = host.strip().lower()
+    if normalized in {"localhost", "127.0.0.1", "::1"} or normalized.endswith(".local"):
+        return "local"
+    try:
+        ip = ipaddress.ip_address(normalized)
+    except ValueError:
+        return "remote"
+    return "local" if ip.is_private or ip.is_loopback else "remote"
+
+
+def build_custom_endpoint_setup_payload(base_url: str, api_key: str = "") -> dict[str, str | bool]:
+    clean_url = str(base_url or "").strip().rstrip("/")
+    clean_key = str(api_key or "").strip()
+    host_label = _custom_endpoint_host_label(clean_url)
+    name = f"Self-hosted ({host_label})"
+    return {
+        "id": host_label,
+        "name": name,
+        "base_url": clean_url,
+        "api_key": clean_key,
+        "auth_required": bool(clean_key),
+        "execution_location": _custom_endpoint_execution_location(clean_url),
+        "transport": "openai_chat",
+    }
+
+
+def custom_endpoint_model_options(model_infos: list) -> dict[str, str]:
+    return {
+        info.selection_ref: f"↔ {info.display_name or info.model_id}"
+        for info in model_infos
+        if getattr(info, "selection_ref", "") and getattr(info, "model_id", "")
+    }
 
 
 async def show_setup_wizard(
@@ -56,6 +102,11 @@ async def show_setup_wizard(
     from agent import clear_agent_cache
     from ui.helpers import mark_setup_complete
     from providers.selection import add_quick_choice_for_model
+    from providers.custom import (
+        endpoint_id_from_provider_id,
+        refresh_custom_endpoint_models,
+        save_custom_endpoint,
+    )
 
     def _open_first_run_migration_wizard() -> None:
         with ui.dialog().props("maximized") as migration_dlg:
@@ -123,12 +174,21 @@ async def show_setup_wizard(
                     setup_path["mode"] = "local"
                     _local_section.visible = True
                     _cloud_section.visible = False
+                    _custom_section.visible = False
                     _update_finish()
 
                 def _pick_cloud():
                     setup_path["mode"] = "cloud"
                     _local_section.visible = False
                     _cloud_section.visible = True
+                    _custom_section.visible = False
+                    _update_finish()
+
+                def _pick_custom():
+                    setup_path["mode"] = "custom"
+                    _local_section.visible = False
+                    _cloud_section.visible = False
+                    _custom_section.visible = True
                     _update_finish()
 
                 ui.button("🖥️ Local (Ollama)", on_click=_pick_local).props(
@@ -137,9 +197,14 @@ async def show_setup_wizard(
                 ui.button("Providers (API key)", on_click=_pick_cloud).props(
                     "color=cyan outline"
                 ).classes("flex-grow")
+                ui.button("Custom/Self-hosted", on_click=_pick_custom).props(
+                    "color=teal outline"
+                ).classes("flex-grow")
 
             _cloud_section = ui.column().classes("w-full")
             _cloud_section.visible = False
+            _custom_section = ui.column().classes("w-full")
+            _custom_section.visible = False
             _local_section = ui.column().classes("w-full")
             _local_section.visible = False
 
@@ -268,6 +333,83 @@ async def show_setup_wizard(
                         _update_finish()
 
                 cloud_model_select.on_value_change(_on_cloud_model_change)
+
+            # ── Custom/Self-hosted Provider Setup Path ───────────────
+            custom_done: dict[str, bool] = {"value": False}
+            custom_models_by_ref: dict[str, object] = {}
+            with _custom_section:
+                ui.label(
+                    "Connect an OpenAI-compatible endpoint such as vLLM, LocalAI, LM Studio, "
+                    "or a private gateway. Leave the API key empty for no-auth endpoints."
+                ).classes("text-grey-6 text-sm")
+
+                custom_url_input = ui.input(
+                    "Base URL",
+                    placeholder="http://127.0.0.1:8000/v1",
+                ).classes("w-full")
+                custom_api_key_input = ui.input(
+                    "API Key (optional)",
+                    password=True,
+                    password_toggle_button=True,
+                ).classes("w-full")
+
+                custom_status = ui.label("").classes("text-sm")
+                custom_status.visible = False
+                custom_model_select = ui.select(
+                    label="Default self-hosted model",
+                    options=[],
+                ).classes("w-full").props("use-input input-debounce=300")
+                custom_model_select.visible = False
+
+                async def _connect_custom_endpoint():
+                    base_url = str(custom_url_input.value or "").strip()
+                    api_key = str(custom_api_key_input.value or "").strip()
+                    if not base_url:
+                        ui.notify("Enter a custom endpoint base URL", type="warning")
+                        return
+                    payload = build_custom_endpoint_setup_payload(base_url, api_key)
+                    custom_status.text = "⏳ Connecting to custom endpoint…"
+                    custom_status.visible = True
+                    custom_model_select.visible = False
+                    custom_done["value"] = False
+                    _update_finish()
+                    try:
+                        await run.io_bound(save_custom_endpoint, payload)
+                        infos = await run.io_bound(
+                            refresh_custom_endpoint_models,
+                            endpoint_id_from_provider_id(str(payload["id"])),
+                        )
+                    except Exception as exc:
+                        logger.warning("Custom endpoint setup failed", exc_info=True)
+                        custom_status.text = f"❌ Could not fetch models: {exc}"
+                        _update_finish()
+                        return
+                    opts = custom_endpoint_model_options(infos)
+                    if not opts:
+                        custom_status.text = "❌ No models found at this endpoint."
+                        _update_finish()
+                        return
+                    custom_models_by_ref.clear()
+                    custom_models_by_ref.update({info.selection_ref: info for info in infos})
+                    custom_model_select.options = opts
+                    first = next(iter(opts))
+                    custom_model_select.set_value(first)
+                    custom_model_select.visible = True
+                    custom_status.text = f"✅ Found {len(opts)} models"
+                    custom_done["value"] = True
+                    _update_finish()
+
+                ui.button(
+                    "Connect & Fetch Models",
+                    icon="hub",
+                    on_click=_connect_custom_endpoint,
+                ).props("color=teal")
+
+                def _on_custom_model_change(e):
+                    custom_done["value"] = bool(e.value)
+                    _update_finish()
+
+                custom_model_select.on_value_change(_on_custom_model_change)
 
             # ── Brain Model (Local path) ─────────────────────────────
             with _local_section:
@@ -566,7 +708,7 @@ async def show_setup_wizard(
                 ),
             ]
             # If provider path was selected, add a tips entry for Quick Choices
-            _is_cloud = setup_path["mode"] == "cloud"
+            _is_cloud = setup_path["mode"] in {"cloud", "custom"}
             if _is_cloud:
                 tips.insert(
                     1,
@@ -596,6 +738,8 @@ async def show_setup_wizard(
                     finish_btn.set_enabled(False)
                 elif setup_path["mode"] == "cloud":
                     finish_btn.set_enabled(cloud_done["value"])
+                elif setup_path["mode"] == "custom":
+                    finish_btn.set_enabled(custom_done["value"])
                 else:
                     finish_btn.set_enabled(brain_done["value"])
 
@@ -612,6 +756,20 @@ async def show_setup_wizard(
                     vsel = cloud_vision_select.value
                     if vsel:
                         state.vision_service.model = vsel
+                elif setup_path["mode"] == "custom":
+                    sel = custom_model_select.value
+                    info = custom_models_by_ref.get(sel)
+                    if sel and info:
+                        set_model(sel)
+                        state.current_model = sel
+                        add_quick_choice_for_model(
+                            info.model_id,
+                            provider_id=info.provider_id,
+                            display_name=info.display_name,
+                            source="setup_default",
+                            capabilities_snapshot=info.capability_snapshot(),
+                        )
+                        clear_agent_cache()
                 mark_setup_complete()
                 setup_dlg.close()
                 await on_finish()


### PR DESCRIPTION
## Summary
- add a Custom/Self-hosted setup path to the first-start wizard
- collect base URL plus optional API key and save through the existing custom endpoint provider config
- fetch endpoint models and allow choosing the default self-hosted chat model during setup

Fixes siddsachar/Thoth#36

## Tests
- THOTH_DATA_DIR=/private/tmp/thoth-pr-test .venv/bin/python -m pytest test_setup_wizard_custom.py test_provider_custom.py test_provider_runtime.py test_provider_selection.py