### PR TITLE
fix: parse Ollama host with port

### DIFF
--- a/models.py
+++ b/models.py
@@ -441,11 +441,24 @@ def get_current_model() -> str:
     return _current_model
 
 
+def _ollama_host_port() -> tuple[str, int]:
+    """Return the TCP host/port configured for the local Ollama daemon."""
+    from urllib.parse import urlparse
+
+    raw = (os.environ.get("OLLAMA_HOST") or "127.0.0.1").strip() or "127.0.0.1"
+    parsed = urlparse(raw if "://" in raw else f"//{raw}")
+    host = parsed.hostname or raw
+    try:
+        port = parsed.port or 11434
+    except ValueError:
+        port = 11434
+    return host, port
+
+
 def _ollama_reachable(timeout: float = 1.0) -> bool:
     """Fast TCP probe to check if the Ollama server is listening."""
     import socket
-    host = os.environ.get("OLLAMA_HOST", "127.0.0.1")
-    port = 11434
+    host, port = _ollama_host_port()
     try:
         with socket.create_connection((host, port), timeout=timeout):
             return True

--- a/test_provider_runtime.py
+++ b/test_provider_runtime.py
@@ -1,4 +1,5 @@
 import sys
+import socket
 from types import ModuleType
 
 import providers.runtime as runtime
@@ -149,6 +150,42 @@ def test_ollama_provider_runtime_constructs_chat_ollama(monkeypatch):
     model = runtime.create_chat_model("qwen3:14b", provider_id="ollama")
 
     assert model.kwargs == {"model": "qwen3:14b", "reasoning": True}
+
+
+def test_ollama_reachable_parses_ollama_host_variants(monkeypatch):
+    import models
+
+    calls = []
+
+    class _FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def _fake_create_connection(address, timeout=None):
+        calls.append((address, timeout))
+        return _FakeConnection()
+
+    monkeypatch.setattr(socket, "create_connection", _fake_create_connection)
+
+    cases = [
+        (None, ("127.0.0.1", 11434)),
+        ("127.0.0.1", ("127.0.0.1", 11434)),
+        ("127.0.0.1:11435", ("127.0.0.1", 11435)),
+        ("http://127.0.0.1:11436", ("127.0.0.1", 11436)),
+        ("localhost:notaport", ("localhost", 11434)),
+        ("[::1]:11437", ("::1", 11437)),
+    ]
+    for value, expected_address in cases:
+        if value is None:
+            monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        else:
+            monkeypatch.setenv("OLLAMA_HOST", value)
+        calls.clear()
+        assert models._ollama_reachable(timeout=0.25) is True
+        assert calls == [(expected_address, 0.25)]
 
 
 def test_provider_errors_normalize_unsupported_capability():


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [x] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `python test_suite.py`
- [x] I added or updated tests
- [x] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
