### PR TITLE
fix: preserve channel streaming around tool calls

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -2104,10 +2104,6 @@ def _stream_graph(agent, input_data, config: dict,
             if meta.get("langgraph_node") != "agent":
                 continue
 
-            # Skip chunks that are part of a tool-call decision
-            if getattr(msg, "tool_calls", []) or getattr(msg, "tool_call_chunks", []):
-                continue
-
             # Track finish_reason from streaming response_metadata
             _rm = getattr(msg, "response_metadata", None) or {}
             _fr = _rm.get("finish_reason")
@@ -2115,6 +2111,9 @@ def _stream_graph(agent, input_data, config: dict,
                 _finish_reason = _fr
 
             content = _content_to_str(msg.content)
+            has_tool_call_chunk = bool(
+                getattr(msg, "tool_calls", []) or getattr(msg, "tool_call_chunks", [])
+            )
 
             # ── Reasoning via additional_kwargs (LangChain standard) ─
             # All major providers (OpenAI, Ollama/DeepSeek, Groq, XAI)
@@ -2129,6 +2128,13 @@ def _stream_graph(agent, input_data, config: dict,
                 yield ("thinking_token", _reasoning)
 
             if not content:
+                # Tool-call chunks often carry only function-call deltas. Those
+                # should not be surfaced as user-visible text, but providers can
+                # also emit normal text in adjacent/mixed chunks before the tool
+                # decision. Preserve text when present instead of dropping the
+                # whole chunk just because tool-call metadata exists.
+                if has_tool_call_chunk:
+                    continue
                 # Empty content = thinking phase (signal spinner if no
                 # reasoning_content was yielded above)
                 if not thinking_signalled:

--- a/channels/discord_channel.py
+++ b/channels/discord_channel.py
@@ -271,6 +271,7 @@ async def _discord_edit_consumer(sent_msg, event_queue: queue.Queue,
     tool_lines: list[str] = []
     last_edit = 0.0
     overflow = False
+    last_sent_display = ""
 
     while True:
         try:
@@ -298,6 +299,7 @@ async def _discord_edit_consumer(sent_msg, event_queue: queue.Queue,
                 continue
             try:
                 await sent_msg.edit(content=display or "⏳")
+                last_sent_display = display
             except Exception:
                 pass
             last_edit = now
@@ -306,9 +308,10 @@ async def _discord_edit_consumer(sent_msg, event_queue: queue.Queue,
     if display and not overflow:
         try:
             await sent_msg.edit(content=display)
+            last_sent_display = display
         except Exception:
             pass
-    return display if not overflow else None
+    return display if not overflow and last_sent_display == display else None
 
 
 def _build_stream_display(tool_lines: list[str], accumulated: str) -> str:

--- a/channels/slack.py
+++ b/channels/slack.py
@@ -296,6 +296,7 @@ async def _slack_edit_consumer(app_client, channel_id: str, msg_ts: str,
     tool_lines: list[str] = []
     last_edit = 0.0
     overflow = False
+    last_sent_display = ""
 
     while True:
         try:
@@ -326,6 +327,7 @@ async def _slack_edit_consumer(app_client, channel_id: str, msg_ts: str,
                     channel=channel_id, ts=msg_ts,
                     text=_md_to_mrkdwn(display) if display else "⏳",
                 )
+                last_sent_display = display
             except Exception:
                 pass
             last_edit = now
@@ -337,9 +339,10 @@ async def _slack_edit_consumer(app_client, channel_id: str, msg_ts: str,
                 channel=channel_id, ts=msg_ts,
                 text=_md_to_mrkdwn(display),
             )
+            last_sent_display = display
         except Exception:
             pass
-    return display if not overflow else None
+    return display if not overflow and last_sent_display == display else None
 
 
 def _build_stream_display(tool_lines: list[str], accumulated: str) -> str:

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -346,6 +346,7 @@ async def _tg_edit_consumer(chat, sent_msg, event_queue: queue.Queue,
     tool_lines: list[str] = []
     last_edit = 0.0
     overflow = False  # set when text exceeds MAX_TG_MESSAGE_LEN
+    last_sent_display = ""
 
     while True:
         try:
@@ -375,9 +376,11 @@ async def _tg_edit_consumer(chat, sent_msg, event_queue: queue.Queue,
             try:
                 html = _md_to_html(display) if display else "⏳"
                 await sent_msg.edit_text(html, parse_mode="HTML")
+                last_sent_display = display
             except Exception:
                 try:
                     await sent_msg.edit_text(display or "⏳")
+                    last_sent_display = display
                 except Exception:
                     pass
             last_edit = now
@@ -388,12 +391,14 @@ async def _tg_edit_consumer(chat, sent_msg, event_queue: queue.Queue,
         try:
             html = _md_to_html(display)
             await sent_msg.edit_text(html, parse_mode="HTML")
+            last_sent_display = display
         except Exception:
             try:
                 await sent_msg.edit_text(display)
+                last_sent_display = display
             except Exception:
                 pass
-    return display if not overflow else None
+    return display if not overflow and last_sent_display == display else None
 
 
 def _build_stream_display(tool_lines: list[str], accumulated: str) -> str:

--- a/tests/test_channel_streaming.py
+++ b/tests/test_channel_streaming.py
@@ -1,0 +1,86 @@
+import asyncio
+import queue
+
+
+def test_stream_graph_preserves_text_on_tool_call_chunks():
+    from agent import _stream_graph
+
+    class AIMessageChunk:
+        def __init__(self, content="", *, tool_calls=None, tool_call_chunks=None):
+            self.content = content
+            self.response_metadata = {}
+            self.additional_kwargs = {}
+            self.tool_calls = tool_calls or []
+            self.tool_call_chunks = tool_call_chunks or []
+
+    class FakeToolCallMessage:
+        type = "ai"
+        content = ""
+        tool_calls = [{"id": "call_search", "name": "web_search", "args": {"query": "test"}}]
+
+    class FakeToolMessage:
+        type = "tool"
+        name = "web_search"
+        content = "result"
+
+    class FakeState:
+        next = None
+        tasks = []
+        values = {"messages": []}
+
+    class FakeAgent:
+        def stream(self, input_data, config, stream_mode):
+            yield ("messages", (AIMessageChunk("I'll"), {"langgraph_node": "agent"}))
+            yield (
+                "messages",
+                (
+                    AIMessageChunk(
+                        " check that now.",
+                        tool_call_chunks=[{"name": "web_search", "args": "{}"}],
+                    ),
+                    {"langgraph_node": "agent"},
+                ),
+            )
+            yield ("updates", {"agent": {"messages": [FakeToolCallMessage()]}})
+            yield ("updates", {"tools": {"messages": [FakeToolMessage()]}})
+            yield ("messages", (AIMessageChunk(" The result is ready."), {"langgraph_node": "agent"}))
+            yield ("updates", {})
+
+        def get_state(self, config):
+            return FakeState()
+
+    events = list(_stream_graph(FakeAgent(), {}, {"configurable": {"thread_id": "test-channel-stream"}}))
+    token_text = "".join(payload for event_type, payload in events if event_type == "token")
+    done_text = [payload for event_type, payload in events if event_type == "done"][-1]
+
+    assert "I'll check that now." in token_text
+    assert "I'll check that now." in done_text
+    assert "The result is ready." in done_text
+
+
+def test_telegram_stream_consumer_returns_none_when_final_edit_fails():
+    from channels.telegram import _tg_edit_consumer
+
+    class FakeSentMessage:
+        def __init__(self):
+            self.edits = []
+
+        async def edit_text(self, text, **kwargs):
+            self.edits.append(text)
+            if "complete" in text:
+                raise RuntimeError("simulated final edit failure")
+
+    async def run_case():
+        events = queue.Queue()
+        events.put(("token", "first"))
+        events.put(("token", " complete"))
+        events.put(None)
+        sent = FakeSentMessage()
+        result = await _tg_edit_consumer(None, sent, events, asyncio.get_running_loop())
+        return result, sent.edits
+
+    result, edits = asyncio.run(run_case())
+
+    assert result is None
+    assert edits[0] == "first"
+    assert any("complete" in edit for edit in edits)


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [x] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `python tests/test_suite.py`
- [x] I added or updated tests
- [ ] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
