### PR TITLE
Clean stale custom endpoint model refs

### DIFF
--- a/models.py
+++ b/models.py
@@ -692,6 +692,7 @@ def set_context_size(size: int):
 
 
 def get_current_model() -> str:
+    _reset_current_model_if_missing_custom_provider()
     return _current_model
 
 
@@ -955,10 +956,74 @@ def _sync_custom_model_cache() -> None:
         entries = custom_model_cache_entries()
     except Exception:
         return
-    if not entries:
-        return
     with _cloud_cache_lock:
+        for model_id, info in list(_cloud_model_cache.items()):
+            if isinstance(info, dict) and str(info.get("provider") or "").startswith("custom_openai_"):
+                replacement = entries.get(model_id)
+                if not replacement or replacement.get("provider") != info.get("provider"):
+                    _cloud_model_cache.pop(model_id, None)
         _cloud_model_cache.update(entries)
+
+
+def reset_current_model_if_removed(
+    provider_id: str,
+    *,
+    removed_model_ids: set[str] | None = None,
+) -> bool:
+    """Reset the saved Brain default if it points at a removed provider/model."""
+    global _current_model, _llm_instance
+    provider_id = str(provider_id or "").strip()
+    if not provider_id:
+        return False
+    try:
+        from providers.selection import list_quick_choices, model_choice_value, parse_model_ref
+    except Exception:
+        return False
+    parsed = parse_model_ref(_current_model)
+    if not parsed:
+        return False
+    current_provider, current_model = parsed
+    removed = {str(model_id) for model_id in (removed_model_ids or set()) if str(model_id)}
+    if current_provider != provider_id:
+        return False
+    if removed and current_model not in removed:
+        return False
+    fallback = ""
+    try:
+        for choice in list_quick_choices("chat"):
+            if choice.get("kind") != "model" or choice.get("active") is False:
+                continue
+            choice_provider = str(choice.get("provider_id") or "")
+            choice_model = str(choice.get("model_id") or "")
+            if choice_provider == provider_id and (not removed or choice_model in removed):
+                continue
+            fallback = model_choice_value(choice_model, provider_id=choice_provider)
+            if fallback:
+                break
+    except Exception:
+        fallback = ""
+    if not fallback:
+        fallback = model_choice_value(DEFAULT_MODEL, provider_id="ollama")
+    _current_model = fallback
+    _llm_instance = None
+    _override_llm_cache.clear()
+    _save_settings({"model": _current_model, "context_size": _num_ctx,
+                    "cloud_context_size": _cloud_num_ctx})
+    return True
+
+
+def _reset_current_model_if_missing_custom_provider() -> None:
+    try:
+        from providers.custom import get_custom_endpoint, is_custom_openai_provider
+        from providers.selection import parse_model_ref
+    except Exception:
+        return
+    parsed = parse_model_ref(_current_model)
+    if not parsed:
+        return
+    provider_id, _model_id = parsed
+    if is_custom_openai_provider(provider_id) and not get_custom_endpoint(provider_id):
+        reset_current_model_if_removed(provider_id)
 
 
 def list_starred_cloud_models() -> list[str]:

--- a/providers/custom.py
+++ b/providers/custom.py
@@ -19,6 +19,19 @@ STREAMING_PROBE_MAX_TOKENS = 128
 logger = logging.getLogger(__name__)
 
 
+class CustomEndpointModelRefreshResult(list):
+    def __init__(
+        self,
+        infos: list[ModelInfo],
+        *,
+        stale_pin_count: int = 0,
+        default_reset: bool = False,
+    ) -> None:
+        super().__init__(infos)
+        self.stale_pin_count = int(stale_pin_count or 0)
+        self.default_reset = bool(default_reset)
+
+
 def _positive_int(value: Any, default: int = 0) -> int:
     try:
         parsed = int(value)
@@ -258,16 +271,41 @@ def save_custom_endpoint(endpoint: dict) -> None:
         set_provider_secret(str(normalized["provider_id"]), "api_key", secret)
 
 
-def delete_custom_endpoint(endpoint_or_provider_id: str) -> None:
+def delete_custom_endpoint(endpoint_or_provider_id: str) -> int:
     endpoint_id = endpoint_id_from_provider_id(endpoint_or_provider_id)
     provider_id = custom_provider_id(endpoint_id)
     cfg = load_provider_config()
+    removed_model_ids: set[str] = set()
+    for item in cfg.get("custom_endpoints", []):
+        if not isinstance(item, dict) or normalize_custom_endpoint(item).get("id") != endpoint_id:
+            continue
+        models = item.get("models") if isinstance(item.get("models"), list) else []
+        removed_model_ids = {
+            str(model.get("model_id") or model.get("id") or "")
+            for model in models
+            if isinstance(model, dict) and str(model.get("model_id") or model.get("id") or "")
+        }
+        break
     cfg["custom_endpoints"] = [
         item for item in cfg.get("custom_endpoints", [])
         if not isinstance(item, dict) or normalize_custom_endpoint(item).get("id") != endpoint_id
     ]
     save_provider_config(cfg)
+    removed_pins = 0
+    try:
+        from providers.selection import remove_quick_choices_for_provider
+
+        removed_pins = remove_quick_choices_for_provider(provider_id)
+    except Exception:
+        logger.debug("Failed to remove quick choices for custom provider %s", provider_id, exc_info=True)
+    try:
+        from models import reset_current_model_if_removed
+
+        reset_current_model_if_removed(provider_id, removed_model_ids=removed_model_ids)
+    except Exception:
+        logger.debug("Failed to reset current model after deleting %s", provider_id, exc_info=True)
     delete_provider_secret(provider_id, "api_key")
+    return removed_pins
 
 
 def custom_endpoint_secret(endpoint_or_provider_id: str) -> str:
@@ -320,7 +358,46 @@ def refresh_custom_endpoint_models(endpoint_or_provider_id: str) -> list[ModelIn
     native_metadata = _fetch_custom_endpoint_native_model_metadata(endpoint, headers=headers)
     infos = model_infos_from_openai_compatible_catalog(endpoint, response.json(), native_metadata_by_model=native_metadata)
     _store_custom_endpoint_models(endpoint["id"], infos)
-    return infos
+    valid_model_ids = {info.model_id for info in infos}
+    stale_pin_count = 0
+    default_reset = False
+    try:
+        from providers.selection import remove_quick_choices_for_missing_models
+
+        stale_pin_count = remove_quick_choices_for_missing_models(str(endpoint["provider_id"]), valid_model_ids)
+    except Exception:
+        logger.debug("Failed to prune stale quick choices for %s", endpoint["provider_id"], exc_info=True)
+    try:
+        previous_model_ids = {
+            str(item.get("model_id") or item.get("id") or "")
+            for item in (endpoint.get("models") if isinstance(endpoint.get("models"), list) else [])
+            if isinstance(item, dict) and str(item.get("model_id") or item.get("id") or "")
+        }
+        removed_model_ids = previous_model_ids - valid_model_ids
+        try:
+            from models import get_current_model
+            from providers.selection import parse_model_ref
+
+            parsed_current = parse_model_ref(get_current_model())
+            if (
+                parsed_current
+                and parsed_current[0] == str(endpoint["provider_id"])
+                and parsed_current[1] not in valid_model_ids
+            ):
+                removed_model_ids.add(parsed_current[1])
+        except Exception:
+            pass
+        if removed_model_ids:
+            from models import reset_current_model_if_removed
+
+            default_reset = reset_current_model_if_removed(str(endpoint["provider_id"]), removed_model_ids=removed_model_ids)
+    except Exception:
+        logger.debug("Failed to reset current model after refreshing %s", endpoint["provider_id"], exc_info=True)
+    return CustomEndpointModelRefreshResult(
+        infos,
+        stale_pin_count=stale_pin_count,
+        default_reset=default_reset,
+    )
 
 
 def probe_custom_endpoint(endpoint_or_provider_id: str, model_id: str | None = None) -> dict[str, Any]:

--- a/providers/model_catalog.py
+++ b/providers/model_catalog.py
@@ -222,6 +222,8 @@ def build_model_catalog_rows(
         if not parsed:
             continue
         provider_id, model_id = parsed
+        if provider_id.startswith("custom_openai_") and not _custom_provider_exists(provider_id):
+            continue
         model_info = model_info_from_metadata(
             provider_id,
             model_id,
@@ -479,6 +481,15 @@ def _custom_model_infos() -> list[ModelInfo]:
                 source="custom_openai_catalog",
             ))
     return infos
+
+
+def _custom_provider_exists(provider_id: str) -> bool:
+    try:
+        from providers.custom import get_custom_endpoint
+
+        return bool(get_custom_endpoint(provider_id))
+    except Exception:
+        return False
 
 
 def _minimax_static_model_infos() -> list[ModelInfo]:

--- a/providers/model_catalog_cache.py
+++ b/providers/model_catalog_cache.py
@@ -133,6 +133,21 @@ def refresh_model_catalog_cache(
     provider_status: dict[str, dict[str, Any]] = {}
     cloud_cache = dict(previous.cloud_cache)
     ollama_rows = list(previous.ollama_rows)
+    stale_custom_pins = 0
+
+    try:
+        from providers.selection import prune_stale_custom_quick_choices
+
+        stale_custom_pins = prune_stale_custom_quick_choices()
+    except Exception as exc:
+        warnings.append(f"Stale custom model cleanup failed: {exc}")
+        logger.warning("Stale custom model cleanup failed during catalog refresh", exc_info=True)
+    try:
+        from models import get_current_model
+
+        get_current_model()
+    except Exception:
+        logger.debug("Could not validate current model during catalog refresh", exc_info=True)
 
     try:
         cloud_cache, cloud_status = _refresh_cloud_cache(provider_id=provider_id)
@@ -164,10 +179,11 @@ def refresh_model_catalog_cache(
         return previous
     write_model_catalog_cache(snapshot)
     logger.info(
-        "perf: model catalog cache refreshed in %.3fs rows=%d warnings=%d reason=%s provider=%s",
+        "perf: model catalog cache refreshed in %.3fs rows=%d warnings=%d stale_custom_pins=%d reason=%s provider=%s",
         time.perf_counter() - started,
         snapshot.total_rows,
         len(snapshot.warnings),
+        stale_custom_pins,
         reason,
         provider_id or "all",
     )

--- a/providers/selection.py
+++ b/providers/selection.py
@@ -346,6 +346,48 @@ def refresh_quick_choice_capability_snapshots() -> list[dict[str, Any]]:
     return quick
 
 
+def prune_stale_custom_quick_choices() -> int:
+    try:
+        from providers.custom import is_custom_openai_provider, list_custom_endpoints
+    except Exception:
+        return 0
+    endpoints = list_custom_endpoints()
+    active_providers = {str(endpoint.get("provider_id") or "") for endpoint in endpoints}
+    known_models_by_provider: dict[str, set[str]] = {}
+    for endpoint in endpoints:
+        provider_id = str(endpoint.get("provider_id") or "")
+        models = endpoint.get("models") if isinstance(endpoint.get("models"), list) else []
+        model_ids = {
+            str(model.get("model_id") or model.get("id") or "")
+            for model in models
+            if isinstance(model, dict) and str(model.get("model_id") or model.get("id") or "")
+        }
+        if provider_id and model_ids:
+            known_models_by_provider[provider_id] = model_ids
+    cfg = load_provider_config()
+    quick = [choice for choice in cfg.get("quick_choices", []) if isinstance(choice, dict)]
+    kept: list[dict[str, Any]] = []
+    removed = 0
+    for choice in quick:
+        provider_id = str(choice.get("provider_id") or "")
+        if not is_custom_openai_provider(provider_id):
+            kept.append(choice)
+            continue
+        model_id = str(choice.get("model_id") or "")
+        if provider_id not in active_providers:
+            removed += 1
+            continue
+        known_models = known_models_by_provider.get(provider_id)
+        if known_models is not None and model_id not in known_models:
+            removed += 1
+            continue
+        kept.append(choice)
+    if removed:
+        cfg["quick_choices"] = kept
+        save_provider_config(cfg)
+    return removed
+
+
 def _media_tool_selection(tool_name: str, default_model: str) -> str:
     try:
         from tools import registry
@@ -571,6 +613,39 @@ def remove_quick_choice_for_model(model_id: str, *, provider_id: str | None = No
         if not isinstance(c, dict) or c.get("id") != ref
     ]
     save_provider_config(cfg)
+
+
+def remove_quick_choices_for_provider(provider_id: str) -> int:
+    provider_id = str(provider_id or "").strip()
+    if not provider_id:
+        return 0
+    cfg = load_provider_config()
+    quick = [c for c in cfg.get("quick_choices", []) if isinstance(c, dict)]
+    kept = [c for c in quick if str(c.get("provider_id") or "") != provider_id]
+    removed = len(quick) - len(kept)
+    if removed:
+        cfg["quick_choices"] = kept
+        save_provider_config(cfg)
+    return removed
+
+
+def remove_quick_choices_for_missing_models(provider_id: str, valid_model_ids: set[str]) -> int:
+    provider_id = str(provider_id or "").strip()
+    valid = {str(model_id) for model_id in valid_model_ids if str(model_id)}
+    if not provider_id:
+        return 0
+    cfg = load_provider_config()
+    quick = [c for c in cfg.get("quick_choices", []) if isinstance(c, dict)]
+    kept = [
+        c for c in quick
+        if str(c.get("provider_id") or "") != provider_id
+        or str(c.get("model_id") or "") in valid
+    ]
+    removed = len(quick) - len(kept)
+    if removed:
+        cfg["quick_choices"] = kept
+        save_provider_config(cfg)
+    return removed
 
 
 def deactivate_quick_choice(

--- a/tests/test_model_catalog_cache.py
+++ b/tests/test_model_catalog_cache.py
@@ -30,9 +30,13 @@ def test_model_catalog_cache_round_trip(tmp_path, monkeypatch):
 
 
 def test_model_catalog_refresh_preserves_last_good_when_empty(tmp_path, monkeypatch):
+    import api_keys
+    import providers.config as provider_config
     import providers.model_catalog_cache as cache
 
     path = tmp_path / "model_catalog_cache.json"
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
     monkeypatch.setattr(cache, "CATALOG_CACHE_PATH", path)
     previous = CatalogCacheSnapshot(
         version=cache.CACHE_VERSION,
@@ -51,6 +55,28 @@ def test_model_catalog_refresh_preserves_last_good_when_empty(tmp_path, monkeypa
 
     assert refreshed.cloud_cache == previous.cloud_cache
     assert cache.read_model_catalog_cache().cloud_cache == previous.cloud_cache
+
+
+def test_model_catalog_refresh_prunes_stale_custom_quick_choices(tmp_path, monkeypatch):
+    import api_keys
+    import providers.config as provider_config
+    import providers.model_catalog_cache as cache
+    from providers.selection import add_quick_choice_for_model
+
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+    monkeypatch.setattr(cache, "CATALOG_CACHE_PATH", tmp_path / "model_catalog_cache.json")
+    monkeypatch.setattr(cache, "_refresh_cloud_cache", lambda provider_id=None: (
+        {"gpt-test": {"provider": "openai", "label": "GPT Test"}},
+        {"openai": {"status": "ok", "count": 1}},
+    ))
+    monkeypatch.setattr(cache, "_refresh_ollama_rows", lambda: [])
+    add_quick_choice_for_model("ghost-model", provider_id="custom_openai_deleted")
+
+    refreshed = cache.refresh_model_catalog_cache(reason="test", force=True)
+
+    assert refreshed.total_rows == 1
+    assert provider_config.load_provider_config()["quick_choices"] == []
 
 
 def test_background_model_catalog_refresh_coalesces(monkeypatch):

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -420,6 +420,26 @@ def test_openrouter_cached_tool_metadata_makes_agent_ready(monkeypatch):
     assert rows[0].status_reason == ""
 
 
+def test_model_catalog_does_not_resurrect_deleted_custom_default(tmp_path, monkeypatch):
+    import providers.config as provider_config
+    import providers.model_catalog as catalog_view
+
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(catalog_view, "_provider_status_by_id", lambda: {})
+    monkeypatch.setattr(catalog_view, "_custom_model_infos", lambda: [])
+    monkeypatch.setattr(catalog_view, "_codex_model_infos", lambda: [])
+    monkeypatch.setattr(catalog_view, "_curated_media_entries", lambda surface: {})
+
+    rows = build_model_catalog_rows(
+        cloud_cache={},
+        ollama_rows=[],
+        defaults={"chat": "model:custom_openai_deleted:ghost-chat"},
+        quick_choices=[],
+    )
+
+    assert rows == []
+
+
 def test_openrouter_cached_no_tool_metadata_is_chat_only(monkeypatch):
     import providers.model_catalog as catalog_view
 

--- a/tests/test_provider_custom.py
+++ b/tests/test_provider_custom.py
@@ -1,3 +1,5 @@
+import api_keys
+import models
 import providers.config as provider_config
 from providers.capabilities import model_supports_surface
 from providers.custom import (
@@ -13,6 +15,7 @@ from providers.custom import (
     refresh_custom_endpoint_models,
     save_custom_endpoint,
 )
+from providers.selection import add_quick_choice_for_model, list_quick_choices, model_choice_value
 
 
 def test_custom_endpoint_catalog_parses_vllm_models(tmp_path, monkeypatch):
@@ -238,6 +241,59 @@ def test_custom_endpoint_delete_removes_config_entry(tmp_path, monkeypatch):
     assert get_custom_endpoint("localai") is None
 
 
+def test_custom_endpoint_delete_removes_only_matching_provider_quick_choices(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+    save_custom_endpoint({
+        "id": "old",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "auth_required": False,
+        "models": [{"id": "shared-model", "model_id": "shared-model"}],
+    })
+    save_custom_endpoint({
+        "id": "new",
+        "base_url": "http://127.0.0.1:9000/v1",
+        "auth_required": False,
+        "models": [{"id": "shared-model", "model_id": "shared-model"}],
+    })
+    add_quick_choice_for_model("shared-model", provider_id=custom_provider_id("old"), display_name="Old Shared")
+    add_quick_choice_for_model("shared-model", provider_id=custom_provider_id("new"), display_name="New Shared")
+
+    removed = delete_custom_endpoint("old")
+
+    assert removed == 1
+    assert get_custom_endpoint("old") is None
+    assert [choice["id"] for choice in list_quick_choices("")] == [
+        f"model:{custom_provider_id('new')}:shared-model"
+    ]
+
+
+def test_custom_endpoint_delete_resets_stale_current_model(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+    monkeypatch.setattr(models, "_SETTINGS_PATH", tmp_path / "model_settings.json")
+    monkeypatch.setattr(models, "_current_model", f"model:{custom_provider_id('old')}:old-model")
+    save_custom_endpoint({
+        "id": "old",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "auth_required": False,
+        "models": [{"id": "old-model", "model_id": "old-model"}],
+    })
+
+    delete_custom_endpoint("old")
+
+    assert models.get_current_model() == model_choice_value(models.DEFAULT_MODEL, provider_id="ollama")
+
+
+def test_get_current_model_resets_previously_deleted_custom_default(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+    monkeypatch.setattr(models, "_SETTINGS_PATH", tmp_path / "model_settings.json")
+    monkeypatch.setattr(models, "_current_model", "model:custom_openai_deleted:ghost-model")
+
+    assert models.get_current_model() == model_choice_value(models.DEFAULT_MODEL, provider_id="ollama")
+
+
 def test_custom_endpoint_refresh_persists_model_cache_entries(tmp_path, monkeypatch):
     monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
     save_custom_endpoint({"id": "dummy", "base_url": "http://127.0.0.1:8000/v1", "auth_required": False})
@@ -258,6 +314,115 @@ def test_custom_endpoint_refresh_persists_model_cache_entries(tmp_path, monkeypa
     assert [info.model_id for info in infos] == ["thoth-dummy-chat"]
     assert entries["thoth-dummy-chat"]["provider"] == custom_provider_id("dummy")
     assert entries["thoth-dummy-chat"]["capabilities_snapshot"]["tasks"] == ["chat"]
+
+
+def test_custom_endpoint_refresh_prunes_removed_model_quick_choices(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+    save_custom_endpoint({
+        "id": "dummy",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "auth_required": False,
+        "models": [
+            {"id": "old-chat", "model_id": "old-chat"},
+            {"id": "new-chat", "model_id": "new-chat"},
+        ],
+    })
+    provider_id = custom_provider_id("dummy")
+    add_quick_choice_for_model("old-chat", provider_id=provider_id)
+    add_quick_choice_for_model("new-chat", provider_id=provider_id)
+
+    class _Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": [{"id": "new-chat", "context_length": 8192}]}
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", lambda *args, **kwargs: _Response())
+
+    infos = refresh_custom_endpoint_models("dummy")
+
+    assert [info.model_id for info in infos] == ["new-chat"]
+    assert getattr(infos, "stale_pin_count") == 1
+    assert [choice["id"] for choice in list_quick_choices("")] == [f"model:{provider_id}:new-chat"]
+
+
+def test_custom_endpoint_refresh_resets_default_for_removed_model(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+    monkeypatch.setattr(models, "_SETTINGS_PATH", tmp_path / "model_settings.json")
+    provider_id = custom_provider_id("dummy")
+    monkeypatch.setattr(models, "_current_model", f"model:{provider_id}:old-chat")
+    save_custom_endpoint({
+        "id": "dummy",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "auth_required": False,
+        "models": [
+            {"id": "old-chat", "model_id": "old-chat"},
+            {"id": "new-chat", "model_id": "new-chat"},
+        ],
+    })
+    add_quick_choice_for_model("new-chat", provider_id=provider_id)
+
+    class _Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": [{"id": "new-chat", "context_length": 8192}]}
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", lambda *args, **kwargs: _Response())
+
+    infos = refresh_custom_endpoint_models("dummy")
+
+    assert getattr(infos, "default_reset") is True
+    assert models.get_current_model() == f"model:{provider_id}:new-chat"
+
+
+def test_custom_endpoint_refresh_resets_default_even_without_previous_model_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+    monkeypatch.setattr(models, "_SETTINGS_PATH", tmp_path / "model_settings.json")
+    provider_id = custom_provider_id("dummy")
+    monkeypatch.setattr(models, "_current_model", f"model:{provider_id}:old-chat")
+    save_custom_endpoint({
+        "id": "dummy",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "auth_required": False,
+    })
+    add_quick_choice_for_model("new-chat", provider_id=provider_id)
+
+    class _Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": [{"id": "new-chat", "context_length": 8192}]}
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", lambda *args, **kwargs: _Response())
+
+    infos = refresh_custom_endpoint_models("dummy")
+
+    assert getattr(infos, "default_reset") is True
+    assert models.get_current_model() == f"model:{provider_id}:new-chat"
+
+
+def test_custom_model_cache_sync_prunes_removed_custom_entries(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(models, "_cloud_model_cache", {
+        "old-chat": {"provider": custom_provider_id("old"), "label": "Old Chat"},
+        "openai-chat": {"provider": "openai", "label": "OpenAI Chat"},
+    })
+
+    models._sync_custom_model_cache()
+
+    assert models._cloud_model_cache == {
+        "openai-chat": {"provider": "openai", "label": "OpenAI Chat"},
+    }
 
 
 def test_llamacpp_refresh_reads_props_context(tmp_path, monkeypatch):

--- a/tests/test_provider_selection.py
+++ b/tests/test_provider_selection.py
@@ -14,7 +14,10 @@ from providers.selection import (
     model_choice_value,
     migrate_legacy_starred_models,
     provider_display_label,
+    prune_stale_custom_quick_choices,
     refresh_quick_choice_capability_snapshots,
+    remove_quick_choices_for_missing_models,
+    remove_quick_choices_for_provider,
     remove_quick_choice_for_model,
     resolve_selection,
 )
@@ -168,6 +171,14 @@ def test_quick_choice_remove_supports_custom_provider_id(tmp_path, monkeypatch):
 def test_quick_choices_keep_same_model_id_for_different_providers(tmp_path, monkeypatch):
     monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
     monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+    provider_config.save_provider_config({
+        "custom_endpoints": [{
+            "id": "lab",
+            "name": "Lab",
+            "base_url": "http://127.0.0.1:8000/v1",
+            "auth_required": False,
+        }],
+    })
 
     add_quick_choice_for_model("shared-model", provider_id="openrouter", display_name="Routed Shared")
     add_quick_choice_for_model("shared-model", provider_id="custom_openai_lab", display_name="Lab Shared")
@@ -179,6 +190,77 @@ def test_quick_choices_keep_same_model_id_for_different_providers(tmp_path, monk
         "model:custom_openai_lab:shared-model",
     }
     assert {choice["display_name"] for choice in choices} == {"Routed Shared", "Lab Shared"}
+
+
+def test_remove_quick_choices_for_provider_is_provider_qualified(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+    provider_config.save_provider_config({
+        "custom_endpoints": [
+            {"id": "old", "name": "Old", "base_url": "http://127.0.0.1:8000/v1", "auth_required": False},
+            {"id": "new", "name": "New", "base_url": "http://127.0.0.1:9000/v1", "auth_required": False},
+        ],
+    })
+
+    add_quick_choice_for_model("shared-model", provider_id="custom_openai_old", display_name="Old Shared")
+    add_quick_choice_for_model("shared-model", provider_id="custom_openai_new", display_name="New Shared")
+
+    assert remove_quick_choices_for_provider("custom_openai_old") == 1
+
+    choices = list_quick_choices("")
+    assert [choice["id"] for choice in choices] == ["model:custom_openai_new:shared-model"]
+
+
+def test_remove_quick_choices_for_missing_models_keeps_valid_provider_models(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+    provider_config.save_provider_config({
+        "custom_endpoints": [
+            {"id": "lab", "name": "Lab", "base_url": "http://127.0.0.1:8000/v1", "auth_required": False},
+            {"id": "other", "name": "Other", "base_url": "http://127.0.0.1:9000/v1", "auth_required": False},
+        ],
+    })
+
+    add_quick_choice_for_model("old-model", provider_id="custom_openai_lab")
+    add_quick_choice_for_model("current-model", provider_id="custom_openai_lab")
+    add_quick_choice_for_model("old-model", provider_id="custom_openai_other")
+
+    assert remove_quick_choices_for_missing_models("custom_openai_lab", {"current-model"}) == 1
+
+    assert {choice["id"] for choice in list_quick_choices("")} == {
+        "model:custom_openai_lab:current-model",
+        "model:custom_openai_other:old-model",
+    }
+
+
+def test_stale_deleted_custom_quick_choice_can_be_pruned(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+
+    add_quick_choice_for_model("ghost-model", provider_id="custom_openai_deleted")
+
+    assert prune_stale_custom_quick_choices() == 1
+    assert provider_config.load_provider_config()["quick_choices"] == []
+
+
+def test_stale_missing_custom_model_is_pruned_when_endpoint_models_are_known(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+    provider_config.save_provider_config({
+        "custom_endpoints": [{
+            "id": "lab",
+            "name": "Lab",
+            "base_url": "http://127.0.0.1:8000/v1",
+            "auth_required": False,
+            "models": [{"id": "current-model", "model_id": "current-model"}],
+        }],
+    })
+    add_quick_choice_for_model("old-model", provider_id="custom_openai_lab")
+    add_quick_choice_for_model("current-model", provider_id="custom_openai_lab")
+
+    assert prune_stale_custom_quick_choices() == 1
+
+    assert [choice["id"] for choice in list_quick_choices("")] == ["model:custom_openai_lab:current-model"]
 
 
 def test_model_choice_options_disambiguate_same_model_id_by_provider(tmp_path, monkeypatch):
@@ -229,7 +311,10 @@ def test_included_ollama_value_stays_provider_qualified(tmp_path, monkeypatch):
     assert options[0]["provider_id"] == "ollama"
 
 
-def test_unknown_bare_selection_resolves_to_ollama_not_openrouter():
+def test_unknown_bare_selection_resolves_to_ollama_not_openrouter(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setattr(api_keys, "get_cloud_config", lambda: {"starred_models": []})
+
     resolved = resolve_selection("qwen3:14b")
 
     assert resolved is not None

--- a/ui/provider_settings.py
+++ b/ui/provider_settings.py
@@ -279,8 +279,14 @@ def build_custom_endpoints_section(on_change=None) -> None:
                     ui.space()
 
                     def _delete(endpoint_id=endpoint["id"]):
-                        delete_custom_endpoint(endpoint_id)
-                        ui.notify("Custom endpoint removed", type="info")
+                        removed_pins = delete_custom_endpoint(endpoint_id) or 0
+                        if removed_pins:
+                            ui.notify(
+                                f"Custom endpoint removed; cleared {removed_pins} stale model picker entr{'y' if removed_pins == 1 else 'ies'}",
+                                type="info",
+                            )
+                        else:
+                            ui.notify("Custom endpoint removed", type="info")
                         if on_change:
                             on_change()
 
@@ -289,7 +295,14 @@ def build_custom_endpoints_section(on_change=None) -> None:
                         try:
                             infos = await run.io_bound(refresh_custom_endpoint_models, endpoint_id)
                             notification.dismiss()
-                            ui.notify(f"Found {len(infos)} model(s)", type="positive")
+                            stale_pin_count = int(getattr(infos, "stale_pin_count", 0) or 0)
+                            default_reset = bool(getattr(infos, "default_reset", False))
+                            suffix = ""
+                            if stale_pin_count:
+                                suffix += f"; removed {stale_pin_count} stale picker entr{'y' if stale_pin_count == 1 else 'ies'}"
+                            if default_reset:
+                                suffix += "; reset stale Brain default"
+                            ui.notify(f"Found {len(infos)} model(s){suffix}", type="positive")
                             if on_change:
                                 on_change()
                         except Exception as exc:


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [x] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `python tests/test_suite.py`
- [x] I added or updated tests
- [x] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
