### PR TITLE
feat(providers): upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Model catalog browsing, pinning, defaults, and Quick Choices live in Settings â†
 | Anthropic | `ANTHROPIC_API_KEY` | Claude models through the direct API. |
 | Google AI | `GOOGLE_API_KEY` | Gemini models, Imagen, and Veo. |
 | xAI | `XAI_API_KEY` | Grok models, Grok Imagine, and Grok Imagine Video. |
-| MiniMax | `MINIMAX_API_KEY` | MiniMax M2 models through the Anthropic-compatible API. |
+| MiniMax | `MINIMAX_API_KEY` | MiniMax M3 and M2.7 models through the Anthropic-compatible API. |
 | OpenRouter | `OPENROUTER_API_KEY` | Access to 100+ provider models. |
 | Ollama Cloud | `OLLAMA_CLOUD_API_KEY` or local daemon sign-in | Direct Ollama Cloud models and cloud-tagged daemon models. |
 | Custom OpenAI-compatible endpoint | Base URL and optional key | Self-hosted or proxy models through profiles for oMLX, LM Studio, vLLM, llama.cpp, LocalAI, LiteLLM, SGLang, and generic servers. |

--- a/models.py
+++ b/models.py
@@ -70,6 +70,7 @@ _CONTEXT_HEURISTICS: list[tuple[str, int]] = [
     ("grok-2",           131_072),  # Grok 2 family           — 131K
     ("grok",             131_072),  # Catch-all Grok          — 131K
     # ── MiniMax ──────────────────────────────────────────────────────
+    ("minimax-m3",       524_288),  # MiniMax M3 Anthropic-compatible model    — 512K
     ("minimax-m2",       204_800),  # MiniMax M2.x Anthropic-compatible models
 ]
 
@@ -1694,13 +1695,9 @@ def _fetch_google_models(api_key: str) -> int:
 _XAI_SKIP_SUBSTRINGS: tuple[str, ...] = ()
 
 _MINIMAX_SUPPORTED_MODELS: tuple[tuple[str, int], ...] = (
+    ("MiniMax-M3", 524_288),
     ("MiniMax-M2.7", 204_800),
     ("MiniMax-M2.7-highspeed", 204_800),
-    ("MiniMax-M2.5", 204_800),
-    ("MiniMax-M2.5-highspeed", 204_800),
-    ("MiniMax-M2.1", 204_800),
-    ("MiniMax-M2.1-highspeed", 204_800),
-    ("MiniMax-M2", 204_800),
 )
 
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -106,13 +106,9 @@ def test_model_catalog_pin_refresh_is_async_safe():
 
 def test_minimax_model_ids_infer_to_minimax_provider():
     for model_id in (
+        "MiniMax-M3",
         "MiniMax-M2.7",
         "MiniMax-M2.7-highspeed",
-        "MiniMax-M2.5",
-        "MiniMax-M2.5-highspeed",
-        "MiniMax-M2.1",
-        "MiniMax-M2.1-highspeed",
-        "MiniMax-M2",
     ):
         assert infer_provider_id(model_id) == "minimax"
 

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -730,12 +730,15 @@ def test_minimax_model_facade_recognizes_static_catalog(monkeypatch):
         models._cloud_model_cache.clear()
         count = models.fetch_cloud_models("minimax")
 
-        assert count == 7
+        assert count == 3
         assert models.is_cloud_model("MiniMax-M2.7") is True
         assert models.get_cloud_provider("MiniMax-M2.7") == "minimax"
         assert models.get_cloud_model_context("MiniMax-M2.7") == 204_800
         assert models.get_provider_emoji("MiniMax-M2.7") == "M"
         assert models._cloud_model_cache["MiniMax-M2.7"]["provider"] == "minimax"
+        assert models.is_cloud_model("MiniMax-M3") is True
+        assert models.get_cloud_provider("MiniMax-M3") == "minimax"
+        assert models.get_cloud_model_context("MiniMax-M3") == 524_288
     finally:
         models._cloud_model_cache.clear()
         models._cloud_model_cache.update(old_cache)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -19606,11 +19606,10 @@ try:
 
     # ── 75d. infer_provider_id routes MiniMax model IDs correctly ─────
     from providers.catalog import infer_provider_id as _infer75
+    assert _infer75("MiniMax-M3") == "minimax", "MiniMax-M3 should infer to minimax provider"
     assert _infer75("MiniMax-M2.7") == "minimax", "MiniMax-M2.7 should infer to minimax provider"
     assert _infer75("MiniMax-M2.7-highspeed") == "minimax", "MiniMax-M2.7-highspeed should infer to minimax provider"
-    assert _infer75("MiniMax-M2.5") == "minimax", "MiniMax-M2.5 should infer to minimax provider"
-    assert _infer75("MiniMax-M2.1-highspeed") == "minimax", "MiniMax-M2.1-highspeed should infer to minimax provider"
-    record("PASS", "75d: infer_provider_id routes MiniMax M2 model IDs to minimax")
+    record("PASS", "75d: infer_provider_id routes MiniMax model IDs to minimax")
 
     # ── 75e. minimax provider definition is well-formed ───────────────
     from providers.catalog import get_provider_definition as _gpd75

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -2095,7 +2095,7 @@ def open_settings(
                 ui.button("Clear", icon="delete", on_click=lambda: _clear_secret("XAI_API_KEY", "xAI key", xai_refresh)).props("flat dense color=negative")
 
         with ui.expansion("MiniMax", icon="bolt", value=False).classes("w-full"):
-            ui.label("Access MiniMax M2 models through the Anthropic-compatible API.").classes("text-grey-6 text-sm")
+            ui.label("Access MiniMax M3 and M2.7 models through the Anthropic-compatible API.").classes("text-grey-6 text-sm")
             minimax_input, minimax_refresh = _secret_input("MiniMax API Key", "MINIMAX_API_KEY")
 
             async def _save_minimax():


### PR DESCRIPTION
## Summary

Upgrade MiniMax model configuration to include the latest M3 model as default, while keeping M2.7 as a compatible alternative and dropping the deprecated older M2.x variants from the static catalog.

## Changes

- Add `MiniMax-M3` to `_MINIMAX_SUPPORTED_MODELS` (`models.py`) with a 524,288 context window and place it first so it becomes the new default Quick Choice
- Add a `minimax-m3` prefix to the context-size heuristic (524288) ahead of the existing `minimax-m2` entry so unknown M3 variants resolve to the right context
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove `MiniMax-M2.5` / `M2.5-highspeed` / `M2.1` / `M2.1-highspeed` / `M2` from the static catalog
- Refresh `README.md` provider table and the `ui/settings.py` MiniMax description to mention M3 and M2.7
- Update `tests/test_provider_catalog.py`, `tests/test_provider_runtime.py`, and the Section 75 assertions in `tests/test_suite.py` to reflect the new catalog (`count == 3`, M3 inference, etc.)

## Why

`MiniMax-M3` is the new flagship model with a 512K context window, 128K max output, and image-input support across both OpenAI- and Anthropic-compatible interfaces. M2.7 stays as a fallback for cases where users prefer the prior generation; the older M2.5 / M2.1 / M2 entries are no longer recommended and only clutter the picker. TTS configuration and the API base URL are unchanged.

## Testing

- `python -m pytest tests/test_provider_catalog.py -k minimax` — 3 passed
- `python -m pytest tests/test_provider_runtime.py -k "test_minimax_model_facade_recognizes_static_catalog or test_minimax_provider_creates"` — 2 passed (count == 3 plus M3 cache assertions)
- `python -m pytest tests/test_model_catalog_cache.py` — 6 passed
- `python -m pytest tests/test_provider_auth_store.py tests/test_opencode_first_class_provider.py -k minimax` — 3 passed

The unrelated `test_minimax_pre_model_trim_uses_anthropic_message_consolidation` failure observed in this environment is a missing-dependency issue (`langchain_classic`) and not related to this change.