### PR TITLE
fix: point site downloads to v3.23.1

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
         "license": "https://www.apache.org/licenses/LICENSE-2.0",
         "url": "https://get-thoth.com/",
         "downloadUrl": "https://github.com/siddsachar/row-bot/releases",
-        "softwareVersion": "4.0.0",
+        "softwareVersion": "3.23.1",
         "author": {
             "@type": "Person",
             "name": "siddsachar",
@@ -1105,8 +1105,8 @@
             <a href="#comparison">Compare</a>
             <a href="contact.html">Contact</a>
             <a href="https://github.com/siddsachar/row-bot" target="_blank">GitHub</a>
-            <a href="https://github.com/siddsachar/row-bot/releases/download/v4.0.0/Row-Bot-4.0.0-Windows-x64.exe" class="nav-dl" data-download="windows">Windows</a>
-            <a href="https://github.com/siddsachar/row-bot/releases/download/v4.0.0/Row-Bot-4.0.0-macOS-arm64.dmg" class="nav-dl" data-download="macos">macOS</a>
+            <a href="https://github.com/siddsachar/row-bot/releases/download/v3.23.1/ThothSetup_3.23.1.exe" class="nav-dl" data-download="windows">Windows</a>
+            <a href="https://github.com/siddsachar/row-bot/releases/download/v3.23.1/Thoth-3.23.1-macOS-arm64.dmg" class="nav-dl" data-download="macos">macOS</a>
             <a href="#linux-install" class="nav-dl" data-download="linux">Linux</a>
         </div>
     </nav>
@@ -1122,8 +1122,8 @@
             Your durable data stays on your machine.
         </p>
         <div class="hero-actions">
-            <a href="https://github.com/siddsachar/row-bot/releases/download/v4.0.0/Row-Bot-4.0.0-Windows-x64.exe" class="btn btn--primary" data-download="windows">Download for Windows <span class="btn-hint">.exe</span></a>
-            <a href="https://github.com/siddsachar/row-bot/releases/download/v4.0.0/Row-Bot-4.0.0-macOS-arm64.dmg" class="btn btn--primary" data-download="macos">Download for macOS <span class="btn-hint">.dmg</span></a>
+            <a href="https://github.com/siddsachar/row-bot/releases/download/v3.23.1/ThothSetup_3.23.1.exe" class="btn btn--primary" data-download="windows">Download for Windows <span class="btn-hint">.exe</span></a>
+            <a href="https://github.com/siddsachar/row-bot/releases/download/v3.23.1/Thoth-3.23.1-macOS-arm64.dmg" class="btn btn--primary" data-download="macos">Download for macOS <span class="btn-hint">.dmg</span></a>
             <a href="#linux-install" class="btn btn--primary" data-download="linux">Install on Linux <span class="btn-hint">curl</span></a>
             <a href="https://github.com/siddsachar/row-bot" class="btn btn--ghost" target="_blank">View on GitHub</a>
         </div>
@@ -1545,11 +1545,11 @@
                 <div class="linux-install-head">
                     <div>
                         <span class="linux-install-label">Linux install</span>
-                        <p>Installs the latest verified XDG user tarball, creates <code>~/.local/bin/row-bot</code>, and uses the same release manifest as in-app updates. Manual tarballs remain available from <a href="https://github.com/siddsachar/row-bot/releases/latest" target="_blank">GitHub Releases</a>.</p>
+                        <p>Installs the published v3.23.1 XDG user tarball, creates <code>~/.local/bin/thoth</code>, and uses the matching Thoth release manifest. Manual tarballs remain available from <a href="https://github.com/siddsachar/row-bot/releases/tag/v3.23.1" target="_blank">GitHub Releases</a>.</p>
                     </div>
                     <button class="copy-command" type="button" data-copy-linux>Copy</button>
                 </div>
-                <code class="linux-command">curl -fsSL https://raw.githubusercontent.com/siddsachar/row-bot/main/installer/install-linux.sh | bash</code>
+                <code class="linux-command">curl -fsSL https://raw.githubusercontent.com/siddsachar/row-bot/v3.23.1/installer/install-linux.sh | THOTH_REPO=siddsachar/row-bot bash -s -- 3.23.1</code>
             </div>
         </div>
     </section>
@@ -1603,8 +1603,8 @@
             <h2>Take back your <em>AI sovereignty</em></h2>
             <p>Free, open source, and yours to keep. No Thoth account. No Thoth subscription. No data harvesting.</p>
             <div class="cta-buttons">
-                <a href="https://github.com/siddsachar/row-bot/releases/download/v4.0.0/Row-Bot-4.0.0-Windows-x64.exe" class="btn btn--primary" data-download="windows">Download for Windows <span class="btn-hint">.exe</span></a>
-                <a href="https://github.com/siddsachar/row-bot/releases/download/v4.0.0/Row-Bot-4.0.0-macOS-arm64.dmg" class="btn btn--primary" data-download="macos">Download for macOS <span class="btn-hint">.dmg</span></a>
+                <a href="https://github.com/siddsachar/row-bot/releases/download/v3.23.1/ThothSetup_3.23.1.exe" class="btn btn--primary" data-download="windows">Download for Windows <span class="btn-hint">.exe</span></a>
+                <a href="https://github.com/siddsachar/row-bot/releases/download/v3.23.1/Thoth-3.23.1-macOS-arm64.dmg" class="btn btn--primary" data-download="macos">Download for macOS <span class="btn-hint">.dmg</span></a>
                 <a href="#linux-install" class="btn btn--primary" data-download="linux">Install on Linux <span class="btn-hint">curl</span></a>
                 <a href="https://github.com/siddsachar/row-bot" class="btn btn--ghost" target="_blank">Star on GitHub</a>
             </div>
@@ -1622,7 +1622,7 @@
 
     <footer>
         <p>
-            &#x1305F; Row-Bot &middot; v4.0.0 &middot; Apache 2.0 &middot;
+            &#x1305F; Row-Bot &middot; v3.23.1 &middot; Apache 2.0 &middot;
             <a href="https://github.com/siddsachar/row-bot" target="_blank">GitHub</a> &middot;
             <a href="contact.html">Contact</a>
         </p>
@@ -1680,7 +1680,7 @@
             });
         });
 
-        const linuxInstallCommand = 'curl -fsSL https://raw.githubusercontent.com/siddsachar/row-bot/main/installer/install-linux.sh | bash';
+        const linuxInstallCommand = 'curl -fsSL https://raw.githubusercontent.com/siddsachar/row-bot/v3.23.1/installer/install-linux.sh | THOTH_REPO=siddsachar/row-bot bash -s -- 3.23.1';
         document.querySelectorAll('[data-copy-linux]').forEach(button => {
             button.addEventListener('click', async () => {
                 const previous = button.textContent;


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [ ] I ran `python tests/test_suite.py`
- [ ] I added or updated tests
- [ ] I manually tested the affected user flow
- [x] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [ ] Branch is based on latest `main`
- [ ] No direct secrets, API keys, local paths, or private data included
- [ ] The change is focused and does not include unrelated cleanup
- [ ] Windows/macOS behavior considered where relevant
