### PR TITLE
fix: repair legacy plugin manifests during rebrand migration

### DIFF
--- a/src/row_bot/app.py
+++ b/src/row_bot/app.py
@@ -803,6 +803,7 @@ async def index():
     # ── Startup warnings ─────────────────────────────────────────────────
     if _st.startup_warnings:
         for msg in _st.startup_warnings:
+            logger.warning("Startup warning shown to user: %s", msg)
             ui.notify(msg, type="warning", timeout=8000, close_button=True)
         _st.startup_warnings.clear()
 

--- a/src/row_bot/migration/row_bot_legacy_rebrand.py
+++ b/src/row_bot/migration/row_bot_legacy_rebrand.py
@@ -405,6 +405,7 @@ def _rewrite_copied_config(target: Path, report: dict[str, Any], *, home: Path) 
         path = target / name
         if path.exists() and path.is_file():
             _rewrite_json_file(path, report, target=target, home=home)
+    _rewrite_installed_plugin_manifests(target, report)
     for base in (
         target / "designer" / "projects",
         target / "designer" / "history",
@@ -425,6 +426,48 @@ def _rewrite_copied_config(target: Path, report: dict[str, Any], *, home: Path) 
         for path in base.rglob("*.json"):
             if path.is_file():
                 _rewrite_json_file(path, report, target=target, home=home)
+
+
+def _rewrite_installed_plugin_manifests(target: Path, report: dict[str, Any]) -> None:
+    plugins_dir = target / "installed_plugins"
+    if not plugins_dir.exists() or not plugins_dir.is_dir():
+        return
+    try:
+        plugin_dirs = [path for path in plugins_dir.iterdir() if path.is_dir()]
+    except OSError as exc:
+        report["warnings"].append(f"Skipped installed plugin manifest repair: {exc}")
+        return
+
+    for plugin_dir in plugin_dirs:
+        manifest_path = plugin_dir / "plugin.json"
+        if not manifest_path.exists() or not manifest_path.is_file():
+            continue
+        try:
+            raw = manifest_path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as exc:
+            report["warnings"].append(
+                f"Skipped plugin manifest version repair for {_rel_to_report(manifest_path, target)}: {exc}"
+            )
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        legacy_min_version = data.get("min_thoth_version")
+        changed = False
+        if legacy_min_version is not None and not data.get("min_row_bot_version"):
+            data["min_row_bot_version"] = legacy_min_version
+            changed = True
+        if "min_thoth_version" in data:
+            data.pop("min_thoth_version", None)
+            changed = True
+        if not changed:
+            continue
+
+        encoded = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+        manifest_path.write_text(encoded, encoding="utf-8")
+        _record(report, "files_rewritten", _rel_to_report(manifest_path, target))
+        report["files_rewritten_count"] += 1
 
 
 def _rewrite_json_file(

--- a/tests/test_row_bot_legacy_rebrand.py
+++ b/tests/test_row_bot_legacy_rebrand.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from row_bot.migration import row_bot_legacy_rebrand as mig
+from row_bot.plugins.manifest import parse_manifest
 
 
 class FakeKeyring:
@@ -20,6 +21,18 @@ class FakeKeyring:
 def _write_json(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _legacy_plugin_manifest(plugin_id: str = "thoth-hacker-news") -> dict:
+    return {
+        "id": plugin_id,
+        "name": "Hacker News Reader",
+        "version": "1.0.0",
+        "min_thoth_version": "3.12.0",
+        "author": {"name": "Thoth", "github": "siddsachar"},
+        "description": "Browse and search Hacker News from Thoth.",
+        "provides": {"tools": [], "skills": []},
+    }
 
 
 def test_rebrand_migration_copies_source_rewrites_config_and_writes_marker(tmp_path):
@@ -312,6 +325,67 @@ def test_rebrand_migration_repairs_already_completed_buddy_paths_without_legacy_
     assert ".thoth" not in json.dumps(manifest)
     assert ".row-bot" in manifest["preview_path"]
     assert ".row-bot" in manifest["motion_pack_path"]
+    assert list((target / "migration_reports").glob("row-bot-v4-rebrand-repair-*.json"))
+
+
+def test_rebrand_migration_repairs_copied_legacy_plugin_manifests(tmp_path):
+    home = tmp_path / "home"
+    source = home / ".thoth"
+    target = home / ".row-bot"
+    source.mkdir(parents=True)
+    _write_json(
+        source / "installed_plugins" / "thoth-hacker-news" / "plugin.json",
+        _legacy_plugin_manifest(),
+    )
+
+    result = mig.ensure_legacy_rebrand_migration(environ={}, home=home, keyring_backend=FakeKeyring())
+
+    assert result["status"] == "completed"
+    assert "installed_plugins/thoth-hacker-news/plugin.json" in result["files_rewritten"]
+    manifest_path = target / "installed_plugins" / "thoth-hacker-news" / "plugin.json"
+    manifest_json = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest_json["min_row_bot_version"] == "3.12.0"
+    assert "min_thoth_version" not in manifest_json
+    assert manifest_json["id"] == "thoth-hacker-news"
+    assert parse_manifest(manifest_path.parent).min_row_bot_version == "3.12.0"
+
+
+def test_rebrand_migration_repairs_already_completed_plugin_manifests(tmp_path):
+    home = tmp_path / "home"
+    target = home / ".row-bot"
+    target.mkdir(parents=True)
+    _write_json(
+        target / "migrations" / "row-bot-v4-rebrand.json",
+        {"migration_id": mig.MIGRATION_ID, "status": "completed", "source": str(home / ".thoth"), "target": str(target)},
+    )
+    _write_json(
+        target / "installed_plugins" / "thoth-rss-reader" / "plugin.json",
+        _legacy_plugin_manifest("thoth-rss-reader"),
+    )
+    modern = _legacy_plugin_manifest("modern-plugin")
+    modern["min_row_bot_version"] = "3.20.0"
+    _write_json(target / "installed_plugins" / "modern-plugin" / "plugin.json", modern)
+
+    result = mig.ensure_legacy_rebrand_migration(environ={}, home=home, keyring_backend=FakeKeyring())
+
+    assert result["status"] == "already_completed"
+    assert sorted(result["files_rewritten"]) == [
+        "installed_plugins/modern-plugin/plugin.json",
+        "installed_plugins/thoth-rss-reader/plugin.json",
+    ]
+
+    legacy_json = json.loads(
+        (target / "installed_plugins" / "thoth-rss-reader" / "plugin.json").read_text(encoding="utf-8")
+    )
+    assert legacy_json["min_row_bot_version"] == "3.12.0"
+    assert "min_thoth_version" not in legacy_json
+    assert parse_manifest(target / "installed_plugins" / "thoth-rss-reader").min_row_bot_version == "3.12.0"
+
+    modern_json = json.loads(
+        (target / "installed_plugins" / "modern-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    assert modern_json["min_row_bot_version"] == "3.20.0"
+    assert "min_thoth_version" not in modern_json
     assert list((target / "migration_reports").glob("row-bot-v4-rebrand-repair-*.json"))
 
 


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [x] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `python tests/test_suite.py`
- [ ] I added or updated tests
- [x] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
