### PR TITLE
Fix Windows Tk smoke DLL path

### DIFF
--- a/installer/build_installer.ps1
+++ b/installer/build_installer.ps1
@@ -202,6 +202,7 @@ Get-ChildItem "$PythonDir\python*._pth" | ForEach-Object {
 Write-Host "      Verifying embedded tkinter..." -ForegroundColor Yellow
 $env:TCL_LIBRARY = Join-Path $PythonDir "tcl\tcl8.6"
 $env:TK_LIBRARY = Join-Path $PythonDir "tcl\tk8.6"
+$env:PATH = (Join-Path $PythonDir "Scripts") + ";" + $PythonDir + ";" + $env:PATH
 $TkSmokeCode = @"
 import _tkinter
 import tkinter

--- a/tests/test_startup_hardening.py
+++ b/tests/test_startup_hardening.py
@@ -203,6 +203,7 @@ def test_windows_installer_build_verifies_tk_runtime():
     assert '-PythonVersion "${{ env.WINDOWS_PYTHON_VERSION }}"' in release_workflow
     assert '$SysPyVersion -ne $PythonVersion' in build_script
     assert 'Resolve-TkSourceFile "_tkinter.pyd"' in build_script
+    assert '$env:PATH = (Join-Path $PythonDir "Scripts") + ";" + $PythonDir + ";" + $env:PATH' in build_script
     assert 'import _tkinter' in build_script
     assert 'import tkinter' in build_script
     assert 'Embedded tkinter verified' in build_script


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [x] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [x] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [ ] I ran `python tests/test_suite.py`
- [ ] I added or updated tests
- [ ] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [ ] Branch is based on latest `main`
- [ ] No direct secrets, API keys, local paths, or private data included
- [ ] The change is focused and does not include unrelated cleanup
- [ ] Windows/macOS behavior considered where relevant
