### PR TITLE
fix(models): resolve Ollama family aliases to installed tags

### DIFF
--- a/src/row_bot/models.py
+++ b/src/row_bot/models.py
@@ -108,6 +108,33 @@ def _runtime_model_name(model_name: str | None) -> str:
     return parsed[1] if parsed else raw
 
 
+def _ollama_runtime_model_name(model_name: str | None) -> str:
+    """Resolve local Ollama family aliases to an installed daemon tag.
+
+    Ollama accepts and displays model families such as ``llama3`` in some UI
+    paths, but the daemon inventory commonly exposes only ``llama3:latest``.
+    Keep explicit tags untouched, and only expand a bare family when the local
+    daemon has one unambiguous installed match.
+    """
+    runtime_model = _runtime_model_name(model_name).strip()
+    if not runtime_model or ":" in runtime_model:
+        return runtime_model
+    try:
+        local_models = list_local_models()
+    except Exception:
+        return runtime_model
+    if runtime_model in local_models:
+        return runtime_model
+    latest = f"{runtime_model}:latest"
+    if latest in local_models:
+        return latest
+    family_matches = [
+        name for name in local_models
+        if name.split(":", 1)[0] == runtime_model
+    ]
+    return family_matches[0] if len(family_matches) == 1 else runtime_model
+
+
 def _provider_qualified_cloud_cache_key(provider_id: str | None, model_id: str | None) -> str:
     provider = str(provider_id or "").strip()
     model = str(model_id or "").strip()
@@ -437,7 +464,7 @@ def get_llm():
         if is_cloud_model(_current_model):
             _llm_instance = _get_cloud_llm(_current_model)
         else:
-            runtime_model = _runtime_model_name(_current_model)
+            runtime_model = _ollama_runtime_model_name(_current_model)
             num_ctx = _local_num_ctx_for(_current_model)
             logger.info("Creating LLM instance: model=%s, num_ctx=%s", runtime_model, num_ctx)
             _llm_instance = _chat_ollama(model=runtime_model, num_ctx=num_ctx)
@@ -472,7 +499,7 @@ def get_llm_for(model_name: str, num_ctx: int | None = None):
     if is_cloud_model(model_name):
         return _get_cloud_llm(model_name)
 
-    runtime_model = _runtime_model_name(model_name)
+    runtime_model = _ollama_runtime_model_name(model_name)
     if num_ctx is None:
         num_ctx = _local_num_ctx_for(model_name)
     key = (runtime_model, num_ctx)
@@ -508,7 +535,7 @@ def get_model_max_context(model_name: str | None = None) -> int | None:
         return ctx if ctx > 0 else None
     if is_cloud_model(raw_name):
         return get_cloud_model_context(raw_name)
-    name = _runtime_model_name(raw_name)
+    name = _ollama_runtime_model_name(raw_name)
     if name in _model_max_ctx_cache:
         return _model_max_ctx_cache[name]
     client = _ollama_client()
@@ -553,7 +580,7 @@ def set_model(model_name: str):
         client = _ollama_client()
         if not is_cloud_model(_current_model) and client:
             try:
-                client.generate(model=_runtime_model_name(_current_model), prompt="", keep_alive=0)
+                client.generate(model=_ollama_runtime_model_name(_current_model), prompt="", keep_alive=0)
             except Exception:
                 logger.debug("Could not unload previous model %s", _current_model, exc_info=True)
     _current_model = model_name
@@ -561,7 +588,7 @@ def set_model(model_name: str):
         _llm_instance = _get_cloud_llm(model_name)
     else:
         _llm_instance = _chat_ollama(
-            model=_runtime_model_name(model_name),
+            model=_ollama_runtime_model_name(model_name),
             num_ctx=_local_num_ctx_for(model_name),
         )
     _save_settings({"model": _current_model, "context_size": _num_ctx,
@@ -713,7 +740,7 @@ def set_context_size(size: int):
         _llm_instance = _get_cloud_llm(_current_model)
     else:
         _llm_instance = _chat_ollama(
-            model=_runtime_model_name(_current_model),
+            model=_ollama_runtime_model_name(_current_model),
             num_ctx=_local_num_ctx_for(_current_model),
         )
     _save_settings({"model": _current_model, "context_size": _num_ctx,

--- a/src/row_bot/providers/runtime.py
+++ b/src/row_bot/providers/runtime.py
@@ -127,15 +127,16 @@ def create_chat_model(model_name: str, provider_id: str | None = None):
     ensure_chat_model_compatible(model_name, provider)
     if provider == "ollama":
         from langchain_ollama import ChatOllama
-        from row_bot.models import _ollama_base_url, get_context_size
+        from row_bot.models import _ollama_base_url, _ollama_runtime_model_name, get_context_size
         from row_bot.providers.ollama import is_ollama_reasoning_model
 
+        runtime_model = _ollama_runtime_model_name(resolved.selection_ref)
         kwargs = {
-            "model": model_name,
+            "model": runtime_model,
             "base_url": _ollama_base_url(),
             "num_ctx": get_context_size(resolved.selection_ref),
         }
-        if is_ollama_reasoning_model(model_name):
+        if is_ollama_reasoning_model(runtime_model):
             kwargs["reasoning"] = True
         return ChatOllama(**kwargs)
     if provider == "ollama_cloud":

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -641,6 +641,26 @@ def test_local_ollama_discovery_uses_http_fallback(monkeypatch):
     assert models.list_local_models() == ["vendor/non-tool-chat:14b"]
 
 
+def test_local_ollama_runtime_expands_unique_family_alias(monkeypatch):
+    import row_bot.models as models
+
+    monkeypatch.setattr(models, "list_local_models", lambda: ["llama3:latest"])
+
+    assert models._ollama_runtime_model_name("model:ollama:llama3") == "llama3:latest"
+
+
+def test_local_ollama_runtime_keeps_ambiguous_family_alias(monkeypatch):
+    import row_bot.models as models
+
+    monkeypatch.setattr(
+        models,
+        "list_local_models",
+        lambda: ["llama3:8b", "llama3:70b"],
+    )
+
+    assert models._ollama_runtime_model_name("model:ollama:llama3") == "llama3"
+
+
 def test_local_ollama_context_uses_http_show_fallback(monkeypatch):
     import row_bot.models as models
 

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -279,6 +279,26 @@ def test_ollama_provider_ref_unwraps_at_runtime_edge(monkeypatch):
     assert model.kwargs["num_ctx"] == 32_768
 
 
+def test_ollama_provider_runtime_expands_unique_family_alias(monkeypatch):
+    fake_module = ModuleType("langchain_ollama")
+
+    class _FakeChatOllama:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    fake_module.ChatOllama = _FakeChatOllama
+    monkeypatch.setitem(sys.modules, "langchain_ollama", fake_module)
+    monkeypatch.setenv("OLLAMA_HOST", "127.0.0.1:11434")
+    monkeypatch.setattr("row_bot.models.list_local_models", lambda: ["llama3:latest"])
+    monkeypatch.setattr("row_bot.models.get_context_size", lambda model_ref=None: 32_768)
+
+    model = runtime.create_chat_model("model:ollama:llama3")
+
+    assert model.kwargs["model"] == "llama3:latest"
+    assert model.kwargs["base_url"] == "http://127.0.0.1:11434"
+    assert model.kwargs["num_ctx"] == 32_768
+
+
 def test_runtime_does_not_implicitly_route_unknown_models_to_openrouter():
     try:
         runtime.create_chat_model("qwen3:14b")


### PR DESCRIPTION
## Summary

- Resolve local Ollama bare-family selections like `model:ollama:llama3` to an installed daemon tag such as `llama3:latest` before calling ChatOllama or `/api/show`
- Keep explicit tags unchanged, and leave ambiguous families unchanged when multiple installed tags exist
- Add regression coverage for unique and ambiguous local Ollama family aliases

## Why

Fixes #178. A picker or persisted override can resolve to a provider-qualified local family such as `model:ollama:llama3`, while the user's daemon inventory may only expose `llama3:latest`. Row-Bot already treats that family as local in availability checks, but runtime calls still used the bare name and could fail even though the model is installed.

## Tests

- `python -m pytest tests/test_provider_catalog.py::test_local_ollama_discovery_uses_http_fallback tests/test_provider_catalog.py::test_local_ollama_runtime_expands_unique_family_alias tests/test_provider_catalog.py::test_local_ollama_runtime_keeps_ambiguous_family_alias tests/test_provider_catalog.py::test_local_ollama_context_uses_http_show_fallback tests/test_provider_selection.py::test_model_choice_value_preserves_ollama_provider_ref tests/test_provider_selection.py::test_included_ollama_value_stays_provider_qualified`
- `python -m py_compile src/row_bot/models.py tests/test_provider_catalog.py`

Note: a broader local pytest run reached the same relevant tests, but unrelated UI/agent tests need optional local dependencies (`nicegui`, `langchain_classic`) that are not installed in this checkout.
