### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/src/row_bot/providers/catalog.py
+++ b/src/row_bot/providers/catalog.py
@@ -59,6 +59,15 @@ PROVIDER_DEFINITIONS: dict[str, ProviderDefinition] = {
         risk_label="third_party_router",
         icon="🌐",
     ),
+    "litellm": ProviderDefinition(
+        id="litellm",
+        display_name="LiteLLM",
+        auth_methods=(AuthMethod.API_KEY,),
+        default_transport=TransportMode.OPENAI_CHAT,
+        base_url="http://localhost:4000/v1",
+        risk_label="third_party_router",
+        icon="🔀",
+    ),
     "opencode_zen": ProviderDefinition(
         id="opencode_zen",
         display_name="OpenCode Zen",

--- a/src/row_bot/providers/runtime.py
+++ b/src/row_bot/providers/runtime.py
@@ -19,6 +19,7 @@ def list_configured_provider_ids() -> list[str]:
             "openai",
             "ollama_cloud",
             "openrouter",
+            "litellm",
             "opencode_zen",
             "opencode_go",
             "atlascloud",

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,22 @@
+import unittest
+
+from row_bot.providers.catalog import PROVIDER_DEFINITIONS, get_provider_definition
+from row_bot.providers.models import AuthMethod, TransportMode
+
+
+class TestLiteLLMProvider(unittest.TestCase):
+    def test_provider_registered(self):
+        self.assertIn("litellm", PROVIDER_DEFINITIONS)
+
+    def test_provider_definition(self):
+        defn = get_provider_definition("litellm")
+        self.assertIsNotNone(defn)
+        self.assertEqual(defn.id, "litellm")
+        self.assertEqual(defn.display_name, "LiteLLM")
+        self.assertEqual(defn.default_transport, TransportMode.OPENAI_CHAT)
+        self.assertEqual(defn.base_url, "http://localhost:4000/v1")
+        self.assertIn(AuthMethod.API_KEY, defn.auth_methods)
+
+    def test_provider_uses_openai_compatible_transport(self):
+        defn = get_provider_definition("litellm")
+        self.assertEqual(defn.default_transport, TransportMode.OPENAI_CHAT)


### PR DESCRIPTION
## Summary

Add [LiteLLM](https://github.com/BerriAI/litellm) as a built-in provider, giving users access to 100+ LLM providers (Anthropic, Azure, Bedrock, Vertex, Groq, Ollama, etc.) through a single OpenAI-compatible proxy.

LiteLLM proxy runs locally and translates requests to any supported provider's native format. Since it speaks OpenAI protocol, it reuses the existing `OPENAI_CHAT` transport with zero new transport code.

**Changes:**
- `src/row_bot/providers/catalog.py` - added `litellm` ProviderDefinition (base_url: `http://localhost:4000/v1`, transport: `OPENAI_CHAT`)
- `src/row_bot/providers/runtime.py` - added `litellm` to configured provider list
- `tests/test_litellm_provider.py` - 3 unit tests

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [x] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `python tests/test_suite.py`
- [x] I added or updated tests
- [ ] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

`python tests/test_suite.py`: 1143 pass, 103 fail (all pre-existing failures from missing optional deps `nicegui` and `langgraph.checkpoint.sqlite`, unrelated to this change).

```
tests/test_litellm_provider.py::TestLiteLLMProvider::test_provider_registered PASSED
tests/test_litellm_provider.py::TestLiteLLMProvider::test_provider_definition PASSED
tests/test_litellm_provider.py::TestLiteLLMProvider::test_provider_uses_openai_compatible_transport PASSED
3 passed in 0.26s
```

Existing provider catalog tests: 41 passed (1 pre-existing nicegui failure).

## Release notes

- [x] User-visible change, release notes needed

Users can now select LiteLLM as a provider and point it at their LiteLLM proxy (`http://localhost:4000`) to access any of 100+ supported LLM providers.

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
