### PR TITLE
fix: handle provider secrets without keyring

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ cd Row-Bot-X.Y.Z-Linux-x86_64
 row-bot
 ```
 
-If `~/.local/bin` is not on `PATH`, run `~/.local/bin/row-bot` or add it to your shell profile. On Linux, provider secrets use Secret Service or KWallet when available. WSL and headless systems can run without a keyring, but new secrets are session-only until secure storage is configured.
+If `~/.local/bin` is not on `PATH`, run `~/.local/bin/row-bot` or add it to your shell profile. On Linux, provider secrets use Secret Service or KWallet when available. WSL and headless systems can run without a keyring, but new secrets are session-only until secure storage is configured. For persistence in headless Linux, run Row-Bot inside a D-Bus session with a Secret Service backend such as `gnome-keyring-daemon`, or explicitly configure another secure Python keyring backend such as an encrypted file keyring.
 
 For browser automation, Chromium may need distro packages that the tarball cannot install. If Playwright reports missing dependencies, run the command it prints, or use `python -m playwright install --with-deps chromium` from a source checkout.
 
@@ -184,7 +184,7 @@ generation rows are filtered out of chat, agent, and vision model surfaces.
 | ngrok | `NGROK_AUTHTOKEN` | Tunnels for inbound webhooks. |
 | Gmail and Google Calendar | Google Cloud OAuth `credentials.json` | Email search/read/draft/send and calendar view/create/update/move/delete. |
 
-Configure providers in Settings, Channels, and Accounts. Keys and in-app ChatGPT / Codex and Claude Subscription OAuth tokens are stored in Windows Credential Manager, macOS Keychain, or Linux Secret Service/KWallet when available. `~/.row-bot/api_keys.json` and `~/.row-bot/providers.json` keep metadata only, such as saved state, provider status, Quick Choices, compatibility profiles, probe results, and masked fingerprints.
+Configure providers in Settings, Channels, and Accounts. Keys and in-app ChatGPT / Codex and Claude Subscription OAuth tokens are stored in Windows Credential Manager, macOS Keychain, or Linux Secret Service/KWallet when available. If secure storage is unavailable, newly entered secrets are usable for the current Row-Bot process only and must be re-entered after restart unless a secure keyring backend is configured. `~/.row-bot/api_keys.json` and `~/.row-bot/providers.json` keep metadata only, such as saved state, provider status, Quick Choices, compatibility profiles, probe results, and masked fingerprints.
 
 Atlas Cloud uses an OpenAI-compatible API, but Row-Bot treats it as a
 first-class provider with its own setup, auth, catalog refresh, provider

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -972,7 +972,7 @@ Runtime code is packaged under `src/row_bot`. The paths below are package-relati
 | **`update_handoff.py`** | Detached Windows update handoff helper that waits for Row-Bot processes/ports to exit before starting the installer |
 | **`stability.py`** | UI callback/error capture, asyncio/thread exception hooks, memory snapshots, event-loop lag logging, and crash diagnostics |
 | **`startup_diagnostics.py`** | Early startup probes for optional native packages that can break app import/startup when partially installed |
-| **`api_keys.py`** + **`secret_store.py`** | API key storage and retrieval for tools and API-key providers, backed by OS keyring with metadata-only local files and legacy plaintext migration |
+| **`api_keys.py`** + **`secret_store.py`** | API key storage and retrieval for tools and API-key providers, backed by OS keyring with metadata-only local files, legacy plaintext migration, and session-only fallback when secure storage is unavailable |
 | **`identity.py`** | Assistant name, personality, and self-improvement preference storage with sanitization |
 | **`self_knowledge.py`** | Capability manifest, identity-line builder, live runtime state builder, and prompt-time self-knowledge assembly |
 | **`insights.py`** | Structured insight store with dedup, pruning, pin/dismiss/apply state, and last-analysis tracking |

--- a/src/row_bot/providers/auth_store.py
+++ b/src/row_bot/providers/auth_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import logging
 import os
 from typing import Any
 
@@ -9,6 +10,8 @@ import row_bot.secret_store as secret_store
 
 from row_bot.providers.config import update_provider_config
 from row_bot.providers.models import AuthMethod, ProviderHealth
+
+logger = logging.getLogger(__name__)
 
 PROVIDER_API_KEY_ENV: dict[str, str] = {
     "openai": "OPENAI_API_KEY",
@@ -25,6 +28,8 @@ PROVIDER_API_KEY_ENV: dict[str, str] = {
 PROVIDER_SECRET_CHUNK_SIZE = 512
 CHUNK_MARKER_SUFFIX = "__chunks"
 CHUNK_VALUE_PREFIX = "v1:"
+_session_provider_secrets: dict[tuple[str, str], str] = {}
+_last_storage_warning = ""
 
 
 def _namespace(provider_id: str) -> str:
@@ -33,6 +38,22 @@ def _namespace(provider_id: str) -> str:
 
 def _credential_name(credential_name: str) -> str:
     return str(credential_name or "api_key").strip() or "api_key"
+
+
+def _session_key(provider_id: str, name: str) -> tuple[str, str]:
+    return (str(provider_id).strip(), _credential_name(name))
+
+
+def _get_session_provider_secret(provider_id: str, name: str) -> str:
+    return _session_provider_secrets.get(_session_key(provider_id, name), "")
+
+
+def _set_session_provider_secret(provider_id: str, name: str, value: str) -> None:
+    _session_provider_secrets[_session_key(provider_id, name)] = str(value)
+
+
+def _delete_session_provider_secret(provider_id: str, name: str) -> None:
+    _session_provider_secrets.pop(_session_key(provider_id, name), None)
 
 
 def _chunk_marker_name(name: str) -> str:
@@ -91,6 +112,9 @@ def _set_provider_secret_value(provider_id: str, name: str, value: str) -> None:
 
 
 def _get_provider_secret_value(provider_id: str, name: str) -> str:
+    session_value = _get_session_provider_secret(provider_id, name)
+    if session_value:
+        return session_value
     count = _chunk_count(provider_id, name)
     if count:
         parts: list[str] = []
@@ -117,7 +141,22 @@ def set_provider_secret(
 ) -> None:
     provider_id = str(provider_id).strip()
     name = _credential_name(credential_name)
-    _set_provider_secret_value(provider_id, name, value)
+    text = str(value)
+    storage_source = "keyring"
+    metadata_source = source
+    try:
+        _set_provider_secret_value(provider_id, name, text)
+        _delete_session_provider_secret(provider_id, name)
+        _clear_storage_warning()
+    except secret_store.SecretStoreError as exc:
+        _set_session_provider_secret(provider_id, name, text)
+        storage_source = "session"
+        if source == "keyring":
+            metadata_source = "session"
+        _set_storage_warning(
+            f"Secure provider secret storage is unavailable; {provider_id}/{name} is saved for this session only."
+        )
+        logger.warning("Using session-only provider secret storage for %s/%s: %s", provider_id, name, exc)
     fingerprint = secret_store.fingerprint(value)
     now = datetime.now(timezone.utc).isoformat()
     method = auth_method or (AuthMethod.API_KEY if name == "api_key" else AuthMethod.CUSTOM)
@@ -131,7 +170,8 @@ def set_provider_secret(
             "auth_method": method_value,
             "health": ProviderHealth.CONNECTED.value,
             "configured": True,
-            "source": source,
+            "source": metadata_source,
+            "secret_storage": storage_source,
             "fingerprint": fingerprint,
             "updated_at": now,
             "last_error": "",
@@ -149,15 +189,13 @@ def get_provider_secret(provider_id: str, credential_name: str = "api_key") -> s
             legacy_value = api_keys.get_key(env_var)
             if legacy_value:
                 return legacy_value
-    try:
-        return _get_provider_secret_value(provider_id, name)
-    except secret_store.SecretStoreError:
-        return ""
+    return _get_provider_secret_value(provider_id, name)
 
 
 def delete_provider_secret(provider_id: str, credential_name: str = "api_key") -> None:
     provider_id = str(provider_id).strip()
     name = _credential_name(credential_name)
+    _delete_session_provider_secret(provider_id, name)
     _delete_chunked_provider_secret(provider_id, name)
     try:
         secret_store.delete_secret(name, namespace=_namespace(provider_id))
@@ -211,6 +249,13 @@ def provider_secret_status(provider_id: str, credential_name: str = "api_key") -
                 "source": source or "api_keys",
                 "fingerprint": fingerprint,
             }
+    session_value = _get_session_provider_secret(provider_id, name)
+    if session_value:
+        return {
+            "configured": True,
+            "source": "session",
+            "fingerprint": secret_store.fingerprint(session_value),
+        }
     try:
         value = _get_provider_secret_value(provider_id, name)
         source = "keyring" if value else ""
@@ -221,3 +266,22 @@ def provider_secret_status(provider_id: str, credential_name: str = "api_key") -
         "source": source,
         "fingerprint": secret_store.fingerprint(value),
     }
+
+
+def get_storage_warning() -> str:
+    return _last_storage_warning
+
+
+def _set_storage_warning(message: str) -> None:
+    global _last_storage_warning
+    _last_storage_warning = message
+
+
+def _clear_storage_warning() -> None:
+    global _last_storage_warning
+    _last_storage_warning = ""
+
+
+def _clear_session_secrets_for_tests() -> None:
+    _session_provider_secrets.clear()
+    _clear_storage_warning()

--- a/src/row_bot/providers/custom.py
+++ b/src/row_bot/providers/custom.py
@@ -353,6 +353,14 @@ def custom_endpoint_secret(endpoint_or_provider_id: str) -> str:
     return get_provider_secret(provider_id, "api_key")
 
 
+def custom_endpoint_auth_missing_message(endpoint: dict[str, Any]) -> str:
+    label = str(endpoint.get("display_name") or endpoint.get("id") or endpoint.get("provider_id") or "custom endpoint")
+    return (
+        f"Custom endpoint '{label}' requires an API key, but no key is available. "
+        "Re-enter the key for this session or configure a secure keyring backend for persistent storage."
+    )
+
+
 def custom_endpoint_models(endpoint_or_provider_id: str) -> list[dict[str, Any]]:
     endpoint = get_custom_endpoint(endpoint_or_provider_id)
     if not endpoint:
@@ -386,11 +394,7 @@ def refresh_custom_endpoint_models(endpoint_or_provider_id: str) -> list[ModelIn
 
     import httpx
 
-    headers = dict(endpoint.get("headers") or {})
-    secret = custom_endpoint_secret(str(endpoint["provider_id"])) if endpoint.get("auth_required") else ""
-    if secret:
-        header_name = str(endpoint.get("api_key_header") or "Authorization")
-        headers[header_name] = f"Bearer {secret}" if header_name.lower() == "authorization" else secret
+    headers = _custom_endpoint_headers(endpoint)
     url = f"{str(endpoint['base_url']).rstrip('/')}/models"
     response = httpx.get(url, headers=headers, timeout=15)
     response.raise_for_status()
@@ -1018,9 +1022,12 @@ def _stream_line_has_usable_delta(line: str) -> bool:
 def _custom_endpoint_headers(endpoint: dict[str, Any]) -> dict[str, str]:
     headers = dict(endpoint.get("headers") or {})
     secret = custom_endpoint_secret(str(endpoint["provider_id"])) if endpoint.get("auth_required") else ""
-    if secret:
-        header_name = str(endpoint.get("api_key_header") or "Authorization")
-        headers[header_name] = f"Bearer {secret}" if header_name.lower() == "authorization" else secret
+    if endpoint.get("auth_required") and not secret:
+        raise ValueError(custom_endpoint_auth_missing_message(endpoint))
+    if not secret:
+        return headers
+    header_name = str(endpoint.get("api_key_header") or "Authorization")
+    headers[header_name] = f"Bearer {secret}" if header_name.lower() == "authorization" else secret
     return headers
 
 

--- a/src/row_bot/providers/runtime.py
+++ b/src/row_bot/providers/runtime.py
@@ -6,7 +6,12 @@ from typing import Any
 from row_bot.providers.capabilities import snapshot_supports_surface
 from row_bot.providers.auth_store import get_provider_secret, provider_secret_status
 from row_bot.providers.catalog import get_provider_definition
-from row_bot.providers.custom import custom_endpoint_secret, get_custom_endpoint, is_custom_openai_provider
+from row_bot.providers.custom import (
+    custom_endpoint_auth_missing_message,
+    custom_endpoint_secret,
+    get_custom_endpoint,
+    is_custom_openai_provider,
+)
 
 
 def is_provider_available(provider_id: str) -> bool:
@@ -289,7 +294,10 @@ def create_chat_model(model_name: str, provider_id: str | None = None):
         endpoint = get_custom_endpoint(provider)
         if not endpoint or not endpoint.get("base_url"):
             raise ValueError("Custom OpenAI-compatible endpoint is missing a base URL.")
-        api_key = custom_endpoint_secret(provider) or "not-needed"
+        api_key = custom_endpoint_secret(provider)
+        if endpoint.get("auth_required") and not api_key:
+            raise ValueError(custom_endpoint_auth_missing_message(endpoint))
+        api_key = api_key or "not-needed"
         if endpoint.get("transport") == "openai_responses":
             from langchain_openai import ChatOpenAI
 

--- a/src/row_bot/ui/provider_settings.py
+++ b/src/row_bot/ui/provider_settings.py
@@ -697,6 +697,11 @@ def build_custom_endpoints_section(on_change=None) -> None:
                                     context_window=context_input.value,
                                 )
                                 save_custom_endpoint(payload)
+                                storage_warning = ""
+                                if payload.get("api_key"):
+                                    from row_bot.providers.auth_store import get_storage_warning as get_provider_storage_warning
+
+                                    storage_warning = get_provider_storage_warning()
                                 notification = ui.notification("Endpoint saved; refreshing models...", type="ongoing", spinner=True, timeout=None)
                                 try:
                                     await run.io_bound(refresh_custom_endpoint_models, endpoint["id"])
@@ -708,7 +713,14 @@ def build_custom_endpoints_section(on_change=None) -> None:
                                         pass
                                     notification.dismiss()
                                     suffix = "; probe again to verify readiness" if stale else ""
-                                    ui.notify(f"Endpoint saved{suffix}", type="positive", close_button=True)
+                                    if storage_warning:
+                                        ui.notify(
+                                            "Endpoint saved for this session only; configure secure storage to persist it",
+                                            type="warning",
+                                            close_button=True,
+                                        )
+                                    else:
+                                        ui.notify(f"Endpoint saved{suffix}", type="positive", close_button=True)
                                 except Exception as exc:
                                     notification.dismiss()
                                     ui.notify(f"Endpoint saved, but model refresh failed: {exc}", type="warning", close_button=True)
@@ -876,7 +888,19 @@ def build_custom_endpoints_section(on_change=None) -> None:
             if manual_caps:
                 payload["manual_capabilities"] = manual_caps
             save_custom_endpoint(payload)
-            ui.notify("Custom endpoint saved", type="positive")
+            storage_warning = ""
+            if payload.get("api_key"):
+                from row_bot.providers.auth_store import get_storage_warning as get_provider_storage_warning
+
+                storage_warning = get_provider_storage_warning()
+            if storage_warning:
+                ui.notify(
+                    "Custom endpoint saved for this session only; configure secure storage to persist it",
+                    type="warning",
+                    close_button=True,
+                )
+            else:
+                ui.notify("Custom endpoint saved", type="positive")
             if on_change:
                 on_change()
 

--- a/src/row_bot/ui/setup_wizard.py
+++ b/src/row_bot/ui/setup_wizard.py
@@ -158,6 +158,7 @@ async def show_setup_wizard(
         refresh_custom_endpoint_models,
         save_custom_endpoint,
     )
+    from row_bot.providers.auth_store import get_storage_warning as get_provider_storage_warning
     from row_bot.providers.codex import (
         codex_runtime_available,
         exchange_codex_device_authorization,
@@ -720,7 +721,11 @@ async def show_setup_wizard(
                     first = next(iter(opts))
                     custom_model_select.set_value(first)
                     custom_model_select.visible = True
-                    custom_status.text = f"✅ Found {len(opts)} models"
+                    storage_warning = get_provider_storage_warning() if api_key else ""
+                    if storage_warning:
+                        custom_status.text = f"✅ Found {len(opts)} models. API key is saved for this session only."
+                    else:
+                        custom_status.text = f"✅ Found {len(opts)} models"
                     custom_done["value"] = True
                     _update_finish()
 

--- a/tests/test_developer_studio_phase10.py
+++ b/tests/test_developer_studio_phase10.py
@@ -448,7 +448,8 @@ def test_active_detached_finalize_preserves_optimistic_user_messages():
     source = (root / "src" / "row_bot" / "ui" / "streaming.py").read_text(encoding="utf-8")
 
     assert "if state.thread_id == gen.thread_id:" in source
-    assert "state.messages.append(a_msg)" in source
+    assert "_insert_assistant_before_future_queued_turns(" in source
+    assert "current_queued_ids=gen.queued_message_ids" in source
     assert "Do not reload the active thread here" in source
     assert "active but UI-detached run may have newer optimistic user" in source
 

--- a/tests/test_onboarding_overhaul.py
+++ b/tests/test_onboarding_overhaul.py
@@ -248,8 +248,8 @@ def test_onboarding_source_contracts_are_wired():
     assert "_missing_starter_workflow_count" in center_src
     assert "Add starters" not in center_src
     assert "SETUP_STEPS" in center_src
-    assert "onboarding_center.py" in installer_src
-    assert "onboarding_state.py" in installer_src
+    assert r'Source: "..\src\row_bot\*"' in installer_src
+    assert "recursesubdirs" in installer_src
 
 
 def test_welcome_message_and_example_prompts_are_current():

--- a/tests/test_provider_auth_store.py
+++ b/tests/test_provider_auth_store.py
@@ -1,7 +1,9 @@
+import json
 import os
 
 import row_bot.api_keys as api_keys
 import row_bot.providers.config as provider_config
+import row_bot.providers.auth_store as auth_store
 from row_bot.providers.auth_store import get_provider_secret, provider_secret_status, set_provider_secret
 from row_bot.secret_store import _set_backend_for_tests
 
@@ -29,6 +31,17 @@ class _LimitedMemoryKeyring(_MemoryKeyring):
         if len(str(value)) > self.max_value_length:
             raise RuntimeError("(1783, 'CredWrite', 'The stub received bad data')")
         super().set_password(service, account, value)
+
+
+class _FailingKeyring:
+    def get_password(self, service, account):
+        raise RuntimeError("No recommended backend was available")
+
+    def set_password(self, service, account, value):
+        raise RuntimeError("No recommended backend was available")
+
+    def delete_password(self, service, account):
+        raise RuntimeError("No recommended backend was available")
 
 
 def test_provider_auth_store_uses_keyring_namespace(tmp_path, monkeypatch):
@@ -121,4 +134,60 @@ def test_provider_auth_store_chunks_large_provider_secret(tmp_path, monkeypatch)
         assert status["configured"] is True
         assert status["fingerprint"] == "****xxxx"
     finally:
+        _set_backend_for_tests(None)
+
+
+def test_provider_auth_store_uses_session_when_keyring_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    backend = _FailingKeyring()
+    auth_store._clear_session_secrets_for_tests()
+    _set_backend_for_tests(backend)
+    try:
+        set_provider_secret("custom_openai_llama", "api_key", "sk-session-secret")
+
+        assert get_provider_secret("custom_openai_llama") == "sk-session-secret"
+        assert provider_secret_status("custom_openai_llama") == {
+            "configured": True,
+            "source": "session",
+            "fingerprint": "****cret",
+        }
+        assert "session only" in auth_store.get_storage_warning()
+
+        raw_config = (tmp_path / "providers.json").read_text(encoding="utf-8")
+        assert "sk-session-secret" not in raw_config
+        provider_entry = json.loads(raw_config)["providers"]["custom_openai_llama"]
+        assert provider_entry["source"] == "session"
+        assert provider_entry["secret_storage"] == "session"
+        assert provider_entry["fingerprint"] == "****cret"
+
+        auth_store._clear_session_secrets_for_tests()
+        assert get_provider_secret("custom_openai_llama") == ""
+        assert provider_secret_status("custom_openai_llama")["configured"] is False
+    finally:
+        auth_store._clear_session_secrets_for_tests()
+        _set_backend_for_tests(None)
+
+
+def test_provider_auth_store_keyring_success_clears_session_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    auth_store._clear_session_secrets_for_tests()
+    _set_backend_for_tests(_FailingKeyring())
+    try:
+        set_provider_secret("custom_openai_llama", "api_key", "sk-session-secret")
+        assert provider_secret_status("custom_openai_llama")["source"] == "session"
+    finally:
+        _set_backend_for_tests(None)
+
+    backend = _MemoryKeyring()
+    _set_backend_for_tests(backend)
+    try:
+        set_provider_secret("custom_openai_llama", "api_key", "sk-keyring-secret")
+
+        assert get_provider_secret("custom_openai_llama") == "sk-keyring-secret"
+        assert provider_secret_status("custom_openai_llama")["source"] == "keyring"
+        raw_config = json.loads((tmp_path / "providers.json").read_text(encoding="utf-8"))
+        assert raw_config["providers"]["custom_openai_llama"]["source"] == "keyring"
+        assert raw_config["providers"]["custom_openai_llama"]["secret_storage"] == "keyring"
+    finally:
+        auth_store._clear_session_secrets_for_tests()
         _set_backend_for_tests(None)

--- a/tests/test_provider_custom.py
+++ b/tests/test_provider_custom.py
@@ -1,7 +1,9 @@
 import row_bot.api_keys as api_keys
 import base64
 import io
+import pytest
 import row_bot.models as models
+import row_bot.providers.auth_store as auth_store
 import row_bot.providers.config as provider_config
 from row_bot.providers.capabilities import model_supports_surface
 from row_bot.providers.custom import (
@@ -18,6 +20,18 @@ from row_bot.providers.custom import (
     save_custom_endpoint,
 )
 from row_bot.providers.selection import add_quick_choice_for_model, list_quick_choices, model_choice_value
+from row_bot.secret_store import _set_backend_for_tests
+
+
+class _FailingKeyring:
+    def get_password(self, service, account):
+        raise RuntimeError("No recommended backend was available")
+
+    def set_password(self, service, account, value):
+        raise RuntimeError("No recommended backend was available")
+
+    def delete_password(self, service, account):
+        raise RuntimeError("No recommended backend was available")
 
 
 def test_custom_endpoint_catalog_reads_models_payload_and_common_capability_fields(tmp_path, monkeypatch):
@@ -436,6 +450,63 @@ def test_custom_endpoint_refresh_persists_model_cache_entries(tmp_path, monkeypa
     assert [info.model_id for info in infos] == ["row-bot-dummy-chat"]
     assert entries["row-bot-dummy-chat"]["provider"] == custom_provider_id("dummy")
     assert entries["row-bot-dummy-chat"]["capabilities_snapshot"]["tasks"] == ["chat"]
+
+
+def test_custom_endpoint_refresh_uses_session_secret_when_keyring_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    auth_store._clear_session_secrets_for_tests()
+    _set_backend_for_tests(_FailingKeyring())
+    try:
+        save_custom_endpoint({
+            "id": "headless",
+            "base_url": "http://127.0.0.1:8000/v1",
+            "auth_required": True,
+            "api_key": "sk-local-session",
+        })
+
+        class _Response:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"data": [{"id": "row-bot-headless-chat", "context_length": 8192}]}
+
+        seen_headers = []
+
+        import httpx
+
+        def _get(url, *args, **kwargs):
+            seen_headers.append(dict(kwargs.get("headers") or {}))
+            return _Response()
+
+        monkeypatch.setattr(httpx, "get", _get)
+
+        infos = refresh_custom_endpoint_models("headless")
+
+        assert [info.model_id for info in infos] == ["row-bot-headless-chat"]
+        assert seen_headers[0]["Authorization"] == "Bearer sk-local-session"
+        assert auth_store.provider_secret_status(custom_provider_id("headless"))["source"] == "session"
+        assert "sk-local-session" not in (tmp_path / "providers.json").read_text(encoding="utf-8")
+    finally:
+        auth_store._clear_session_secrets_for_tests()
+        _set_backend_for_tests(None)
+
+
+def test_auth_required_custom_endpoint_refresh_fails_before_http_without_secret(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    auth_store._clear_session_secrets_for_tests()
+    save_custom_endpoint({
+        "id": "missing-key",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "auth_required": True,
+    })
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("HTTP should not be called")))
+
+    with pytest.raises(ValueError, match="requires an API key"):
+        refresh_custom_endpoint_models("missing-key")
 
 
 def test_custom_endpoint_refresh_prunes_removed_model_quick_choices(tmp_path, monkeypatch):

--- a/tests/test_thinking_retention.py
+++ b/tests/test_thinking_retention.py
@@ -27,7 +27,8 @@ def test_streaming_final_message_persists_thinking_text():
     source = (root / "src" / "row_bot" / "ui" / "streaming.py").read_text(encoding="utf-8")
 
     assert "attach_thinking_to_message(a_msg, gen.thinking_text)" in source
-    assert "state.messages.append(a_msg)" in source
+    assert "_insert_assistant_before_future_queued_turns(" in source
+    assert "a_msg," in source
 
 
 def test_streaming_does_not_treat_reasoning_only_as_final_output():


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [x] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `python tests/test_suite.py`
- [x] I added or updated tests
- [x] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [x] User-visible change, release notes needed
- [ ] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
