### PR TITLE
chore(deps): use uv for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  # Python dependencies are resolved by uv.lock; requirements.txt is generated
+  # from that lockfile for installer compatibility.
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly

--- a/.github/workflows/uv-lockfile-check.yml
+++ b/.github/workflows/uv-lockfile-check.yml
@@ -7,6 +7,7 @@ on:
       - "uv.lock"
       - "requirements.txt"
       - "scripts/export_locked_requirements.py"
+      - ".github/dependabot.yml"
       - ".github/workflows/uv-lockfile-check.yml"
       - ".github/workflows/ci.yml"
       - ".github/workflows/release.yml"

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -4,6 +4,8 @@ import re
 import tomllib
 from pathlib import Path
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "pyproject.toml"
@@ -134,6 +136,18 @@ def test_lockfile_and_generated_requirements_are_committed():
     )
 
 
+def test_dependabot_uses_uv_for_python_updates():
+    dependabot = yaml.safe_load((ROOT / ".github/dependabot.yml").read_text(encoding="utf-8"))
+    updates = dependabot["updates"]
+    ecosystems = {entry["package-ecosystem"]: entry for entry in updates}
+
+    assert "uv" in ecosystems
+    assert "pip" not in ecosystems
+    assert ecosystems["uv"]["directory"] == "/"
+    assert ecosystems["uv"]["labels"] == ["dependencies", "python"]
+    assert ecosystems["github-actions"]["labels"] == ["dependencies", "github-actions"]
+
+
 def test_payload_manifest_includes_dependency_provenance_files():
     import scripts.app_payload_manifest as manifest
 
@@ -156,6 +170,7 @@ def test_ci_security_and_installer_dependency_hooks_are_wired():
     assert "uv sync --locked --all-extras --group test" in release
     assert "uv sync --locked --group lint" in lint
     assert lock_check.is_file()
+    assert ".github/dependabot.yml" in lock_check.read_text(encoding="utf-8")
     assert "uv lock --check" in lock_check.read_text(encoding="utf-8")
     assert "export_locked_requirements.py --check" in lock_check.read_text(encoding="utf-8")
     assert osv.is_file()


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [x] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `uv run python scripts/run_test_matrix.py fast`
- [x] I ran `uv run python scripts/run_test_matrix.py pr` for shared, release-sensitive, or cross-subsystem changes
- [x] I added or updated tests
- [x] I updated the relevant inventory in `tests/helpers/` when changing coverage ownership
- [ ] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
