### PR TITLE
Make prompt context caching explicit

### DIFF
--- a/docs/PROMPT_CONTEXT_AND_CACHE.md
+++ b/docs/PROMPT_CONTEXT_AND_CACHE.md
@@ -1,0 +1,70 @@
+# Prompt Context And Cache Contract
+
+Row-Bot assembles prompts from named sections with explicit stability. This
+keeps provider payloads predictable and prevents per-turn data from being marked
+as cacheable provider input.
+
+## Stability Classes
+
+Stable sections may be reused across turns when user settings, provider/model
+selection, enabled tools, skills, plugins, or thread profile configuration have
+not changed. Ephemeral sections are generated for the current turn and must not
+be prompt-cache breakpoints.
+
+Cache-eligible stable sections:
+
+- `agent.root`: identity line and agent guidelines from the ReAct system prompt.
+- `agent.profile`: active thread Agent Profile instructions.
+- `platform.context`: local platform and shell guidance.
+- `self_knowledge.static`: static Row-Bot feature knowledge and optional
+  self-improvement guidance.
+- `skills.tool_guides`: automatic tool guide instructions for enabled tools.
+- `skills.manual`: explicitly or globally enabled manual skills.
+- `skills.plugins`: enabled plugin skill instructions.
+- `background.override`: static background-workflow override.
+- `chat_only.root`: Chat Only identity, behavior rules, and profile context.
+
+Ephemeral sections:
+
+- `turn.date_time`: current date/time line.
+- `turn.runtime_mode`: active runtime mode, approval mode, and enabled tool
+  names for this turn.
+- `turn.conversation_summary`: checkpoint summary merged for context trimming.
+- `turn.memory_recall`: auto-recalled long-term memory block.
+- `self_knowledge.dynamic_state`: current provider/model, channels, MCP,
+  Designer, Dream Cycle, and update status.
+- `turn.developer_context`: Developer Studio repository/runtime context.
+- `turn.designer_project`: active Designer project prompt.
+- `turn.background_persistent_thread`: persistent-thread reminder.
+- `turn.channel_state`: channel-specific transient state.
+- `turn.wind_down`: tool-call-limit warning.
+- Conversation, assistant, and tool history.
+
+## Provider Rules
+
+Direct Anthropic API is the only provider that receives Anthropic
+`cache_control` markers in this rollout. Markers are placed only on stable
+system content. Conversation history and ephemeral system sections must never be
+marked.
+
+Anthropic-compatible routes that are not the direct Anthropic API, including
+MiniMax, OpenCode Anthropic Messages, and Claude Subscription, do not receive
+`cache_control` markers until their transports are explicitly proven to preserve
+and accept those content blocks.
+
+OpenAI, OpenRouter, xAI OAuth Responses, Codex Responses, AtlasCloud, and custom
+OpenAI-compatible endpoints do not receive Anthropic markers. Codex keeps its
+existing `prompt_cache_key` behavior.
+
+## Verification
+
+Deterministic tests assert the section inventory, stable-prefix fingerprint
+behavior, provider marker gating, Chat Only separation, source-test-map
+selection, and provider transport regressions.
+
+Live provider validation is opt-in. When run, it uses the real Row-Bot runtime
+and at least one latest recommended chat-capable model per configured provider.
+The only acceptable provider-side failure is an explicit out-of-credits, quota,
+usage-exhausted, or billing-limit response. Any authentication, schema,
+unsupported parameter, cache-control, tool-call replay, streaming, routing, or
+serialization failure is a bug or blocker.

--- a/src/row_bot/agent.py
+++ b/src/row_bot/agent.py
@@ -6,8 +6,14 @@ from typing import Any
 from row_bot.models import get_llm, get_llm_for, get_context_size, get_current_model, is_model_local, is_cloud_model, get_cloud_provider, get_model_max_context, set_active_model_override, _active_model_override
 from row_bot.api_keys import apply_keys
 from row_bot.prompts import AGENT_SYSTEM_PROMPT, SUMMARIZE_PROMPT, get_agent_system_prompt, get_chat_only_system_prompt
-from langchain_classic.retrievers import ContextualCompressionRetriever
-from langchain_classic.retrievers.document_compressors import LLMChainExtractor
+from row_bot.prompt_cache import apply_anthropic_system_cache_marker, normalize_prompt_cache_usage
+from row_bot.prompt_context import (
+    cache_eligible_message_ids,
+    ephemeral_section,
+    section_messages,
+    stable_prefix_fingerprint,
+    stable_section,
+)
 from langchain_core.messages import trim_messages, ToolMessage, AIMessage, HumanMessage, SystemMessage, BaseMessage
 from langgraph.types import interrupt, Command
 from row_bot.threads import pick_or_create_thread, checkpointer
@@ -397,6 +403,8 @@ def _get_compressor():
         return None
 
     # mode == "deep" — LLMChainExtractor behaviour
+    from langchain_classic.retrievers.document_compressors import LLMChainExtractor
+
     _ov = _model_override_var.get() or ""
     if _ov and _ov != get_current_model() and (is_model_local(_ov) or is_cloud_model(_ov)):
         _compressor = LLMChainExtractor.from_llm(get_llm_for(_ov))
@@ -410,6 +418,8 @@ def _compressed(base_retriever):
     comp = _get_compressor()
     if comp is None:
         return base_retriever
+    from langchain_classic.retrievers import ContextualCompressionRetriever
+
     return ContextualCompressionRetriever(
         base_compressor=comp,
         base_retriever=base_retriever,
@@ -1133,6 +1143,15 @@ def _summarize_tool_result(name: str, content: str) -> str:
     return f"[{name}]: {content[:150]}…"
 
 
+def _cache_eligible_root_system_section(message: SystemMessage):
+    text = _content_to_str(getattr(message, "content", "") or "")
+    if not text.strip():
+        return None
+    if "[Conversation Summary" in text or "[End of summary" in text:
+        return None
+    return stable_section("agent.root", text, source="agent")
+
+
 def _pre_model_trim(state: dict) -> dict:
     """Trim conversation history to ~85% of the context window before each
     LLM call, and inject the current date/time so it is always accurate.
@@ -1456,40 +1475,86 @@ def _pre_model_trim(state: dict) -> dict:
             insert_idx = i + 1
             break
 
-    _injections: list[SystemMessage] = []
+    _prompt_sections = []
+    _cache_eligible_system_message_ids: set[int] = set()
+    _stable_fingerprint = ""
+
+    for _root_candidate in trimmed:
+        if isinstance(_root_candidate, SystemMessage):
+            _root_section = _cache_eligible_root_system_section(_root_candidate)
+            if _root_section is not None:
+                _prompt_sections.append(_root_section)
+                _cache_eligible_system_message_ids.add(id(_root_candidate))
+            break
+
+    _stable_injection_sections = []
+    _ephemeral_injection_sections = []
 
     # Date/time — always present
     now = _datetime.now()
-    _injections.append(SystemMessage(
-        content=f"Current date and time: {now.strftime('%A, %B %d, %Y at %I:%M %p')}."
-    ))
+    _section = ephemeral_section(
+        "turn.date_time",
+        f"Current date and time: {now.strftime('%A, %B %d, %Y at %I:%M %p')}.",
+        source="agent",
+    )
+    if _section is not None:
+        _ephemeral_injection_sections.append(_section)
 
     # Current runtime authority. This prevents stale Chat Only assistant text
     # from a previous turn from overriding the active Agent/tool contract.
-    _injections.append(SystemMessage(content=_agent_runtime_system_context()))
+    _section = ephemeral_section(
+        "turn.runtime_mode",
+        _agent_runtime_system_context(),
+        source="agent",
+    )
+    if _section is not None:
+        _ephemeral_injection_sections.append(_section)
 
     profile_context = _agent_profile_system_context(_current_thread_id_var.get() or "")
     if profile_context:
-        _injections.append(SystemMessage(content=profile_context))
+        _section = stable_section("agent.profile", profile_context, source="agent_profiles")
+        if _section is not None:
+            _stable_injection_sections.append(_section)
 
     # Platform / shell context
     try:
         from row_bot.prompts import get_platform_context
-        _injections.append(SystemMessage(content=get_platform_context()))
+        _section = stable_section("platform.context", get_platform_context(), source="prompts")
+        if _section is not None:
+            _stable_injection_sections.append(_section)
     except Exception:
         pass
 
     developer_context = _developer_context_var.get("")
     if developer_context:
-        _injections.append(SystemMessage(content=developer_context))
+        _section = ephemeral_section("turn.developer_context", developer_context, source="developer")
+        if _section is not None:
+            _ephemeral_injection_sections.append(_section)
 
     # Self-knowledge
     if not compact_custom_endpoint:
         try:
-            from row_bot.self_knowledge import build_self_knowledge_block
-            _sk_text = build_self_knowledge_block()
-            if _sk_text:
-                _injections.append(SystemMessage(content=_sk_text))
+            from row_bot.self_knowledge import (
+                build_dynamic_self_knowledge_block,
+                build_static_self_knowledge_block,
+            )
+
+            _sk_static = build_static_self_knowledge_block()
+            _section = stable_section(
+                "self_knowledge.static",
+                _sk_static,
+                source="self_knowledge",
+            )
+            if _section is not None:
+                _stable_injection_sections.append(_section)
+            _sk_dynamic = build_dynamic_self_knowledge_block()
+            _section = ephemeral_section(
+                "self_knowledge.dynamic_state",
+                _sk_dynamic,
+                source="self_knowledge",
+            )
+            if _section is not None:
+                _ephemeral_injection_sections.append(_section)
         except Exception:
             pass
 
@@ -1500,21 +1565,39 @@ def _pre_model_trim(state: dict) -> dict:
         _dp = get_active_project()
         if _dp is not None:
             from row_bot.designer.prompt import build_designer_prompt
-            _injections.append(SystemMessage(content=build_designer_prompt(_dp)))
+            _section = ephemeral_section(
+                "turn.designer_project",
+                build_designer_prompt(_dp),
+                source="designer",
+            )
+            if _section is not None:
+                _ephemeral_injection_sections.append(_section)
     except Exception:
         pass
 
     # Background-mode override
     if is_background_workflow():
         from row_bot.prompts import AGENT_BG_OVERRIDE
-        _injections.append(SystemMessage(content=AGENT_BG_OVERRIDE))
+        _section = stable_section(
+            "background.override",
+            AGENT_BG_OVERRIDE,
+            source="prompts",
+        )
+        if _section is not None:
+            _stable_injection_sections.append(_section)
         if _persistent_thread_var.get():
-            _injections.append(SystemMessage(content=(
-                "PERSISTENT THREAD: This task uses a persistent conversation thread. "
-                "Earlier messages in this thread are from PREVIOUS runs of the same task. "
-                "Use them to compare against prior results, track changes over time, "
-                "and avoid repeating work already done."
-            )))
+            _section = ephemeral_section(
+                "turn.background_persistent_thread",
+                (
+                    "PERSISTENT THREAD: This task uses a persistent conversation thread. "
+                    "Earlier messages in this thread are from PREVIOUS runs of the same task. "
+                    "Use them to compare against prior results, track changes over time, "
+                    "and avoid repeating work already done."
+                ),
+                source="tasks",
+            )
+            if _section is not None:
+                _ephemeral_injection_sections.append(_section)
 
     # Skill instructions
     skills_text = ""
@@ -1561,12 +1644,31 @@ def _pre_model_trim(state: dict) -> dict:
                     is_background=False,
                 )
 
-            skills_text = get_skills_prompt(
-                manual_skill_names,
+            tool_guides_text = get_skills_prompt(
+                [],
                 active_tool_names=active_tool_names,
             )
-            if skills_text:
-                _injections.append(SystemMessage(content=skills_text))
+            manual_skills_text = get_skills_prompt(
+                manual_skill_names,
+                active_tool_names=[],
+            )
+            skills_text = "\n".join(
+                text for text in (tool_guides_text, manual_skills_text) if text
+            )
+            _section = stable_section(
+                "skills.tool_guides",
+                tool_guides_text,
+                source="skills",
+            )
+            if _section is not None:
+                _stable_injection_sections.append(_section)
+            _section = stable_section(
+                "skills.manual",
+                manual_skills_text,
+                source="skills",
+            )
+            if _section is not None:
+                _stable_injection_sections.append(_section)
             if _thread_id and manual_skill_names:
                 record_usage(_thread_id, manual_skill_names, source="agent")
         except Exception as exc:
@@ -1577,7 +1679,13 @@ def _pre_model_trim(state: dict) -> dict:
 
                     skills_text = _fallback_get_skills_prompt()
                     if skills_text:
-                        _injections.append(SystemMessage(content=skills_text))
+                        _section = stable_section(
+                            "skills.manual",
+                            skills_text,
+                            source="skills",
+                        )
+                        if _section is not None:
+                            _stable_injection_sections.append(_section)
                 except Exception:
                     pass
 
@@ -1587,13 +1695,24 @@ def _pre_model_trim(state: dict) -> dict:
             from row_bot.plugins import registry as _plugin_reg
             plugin_skills_text = _plugin_reg.get_skills_prompt()
             if plugin_skills_text:
-                _injections.append(SystemMessage(content=plugin_skills_text))
+                _section = stable_section(
+                    "skills.plugins",
+                    plugin_skills_text,
+                    source="plugins",
+                )
+                if _section is not None:
+                    _stable_injection_sections.append(_section)
         except Exception as exc:
             logger.debug("Plugin skill injection skipped: %s", exc)
 
     # Batch-insert all injections at insert_idx
-    for _ii, _inj_msg in enumerate(_injections):
-        trimmed.insert(insert_idx + _ii, _inj_msg)
+    _injection_sections = _stable_injection_sections + _ephemeral_injection_sections
+    _prompt_sections.extend(_injection_sections)
+    _section_messages = section_messages(_injection_sections)
+    _cache_eligible_system_message_ids.update(cache_eligible_message_ids(_section_messages))
+    _stable_fingerprint = stable_prefix_fingerprint(_prompt_sections)
+    for _ii, _section_message in enumerate(_section_messages):
+        trimmed.insert(insert_idx + _ii, _section_message.message)
 
     # ── Auto-recall: inject validated background memory before latest user ─
     try:
@@ -1829,12 +1948,8 @@ def _pre_model_trim(state: dict) -> dict:
             trimmed = _sys + _rest
 
             # ── Anthropic prompt caching ─────────────────────────────
-            # Mark the merged system block and early conversation turns
-            # with cache_control so Anthropic caches them across requests.
-            # langchain-anthropic passes cache_control through on content
-            # blocks.  We place up to 2 cache breakpoints:
-            #   1. The last SystemMessage (covers system prompt + metadata)
-            #   2. The 3rd non-system message (covers early conversation)
+            # Only direct Anthropic API receives cache_control, and only on
+            # stable system context. Conversation history is never marked.
             if _provider_id != "anthropic":
                 return {
                     "llm_input_messages": _normalize_provider_facing_messages(
@@ -1843,51 +1958,19 @@ def _pre_model_trim(state: dict) -> dict:
                         anthropic_messages=True,
                     )
                 }
-            _CACHE_MARKER = {"type": "ephemeral"}
-            # Breakpoint 1: last system message
-            _last_sys_idx = -1
-            for _ci in range(len(trimmed) - 1, -1, -1):
-                if isinstance(trimmed[_ci], SystemMessage):
-                    _last_sys_idx = _ci
-                    break
-            if _last_sys_idx >= 0:
-                _sm = trimmed[_last_sys_idx]
-                _sc = _sm.content
-                if isinstance(_sc, str):
-                    _sc = [{"type": "text", "text": _sc, "cache_control": _CACHE_MARKER}]
-                elif isinstance(_sc, list) and _sc:
-                    _sc = list(_sc)  # shallow copy
-                    _last_block = _sc[-1]
-                    if isinstance(_last_block, dict):
-                        _sc[-1] = {**_last_block, "cache_control": _CACHE_MARKER}
-                    else:
-                        _sc.append({"type": "text", "text": "", "cache_control": _CACHE_MARKER})
-                trimmed[_last_sys_idx] = SystemMessage(content=_sc)
-
-            # Breakpoint 2: 3rd non-system message (early conversation)
-            _nonsys_count = 0
-            for _ci, _cm in enumerate(trimmed):
-                if isinstance(_cm, SystemMessage):
-                    continue
-                _nonsys_count += 1
-                if _nonsys_count == 3:
-                    _cc = _cm.content
-                    if isinstance(_cc, str):
-                        _cc = [{"type": "text", "text": _cc, "cache_control": _CACHE_MARKER}]
-                    elif isinstance(_cc, list) and _cc:
-                        _cc = list(_cc)
-                        _lb = _cc[-1]
-                        if isinstance(_lb, dict):
-                            _cc[-1] = {**_lb, "cache_control": _CACHE_MARKER}
-                        else:
-                            _cc.append({"type": "text", "text": "", "cache_control": _CACHE_MARKER})
-                    # Reconstruct message preserving type
-                    _new_msg = _cm.model_copy(update={"content": _cc})
-                    trimmed[_ci] = _new_msg
-                    break
-            logger.debug("Anthropic prompt caching: applied breakpoints "
-                         "(sys=%d, conv=%s)", _last_sys_idx >= 0,
-                         _nonsys_count >= 3)
+            trimmed, _cache_marker_result = apply_anthropic_system_cache_marker(
+                trimmed,
+                provider_id=_provider_id,
+                cache_eligible_system_message_ids=_cache_eligible_system_message_ids,
+                stable_fingerprint=_stable_fingerprint,
+            )
+            logger.debug(
+                "Anthropic prompt caching: applied=%s eligible_systems=%d fingerprint=%s reason=%s",
+                _cache_marker_result.applied,
+                _cache_marker_result.eligible_system_count,
+                _cache_marker_result.stable_fingerprint[:16],
+                _cache_marker_result.reason,
+            )
     except Exception:
         pass  # Non-fatal
 
@@ -3321,6 +3404,7 @@ def stream_chat_only(
     ) * 1000.0
     full_answer: list[str] = []
     full_reasoning: list[str] = []
+    latest_response_metadata: dict[str, Any] = {}
     thinking_signalled = False
     decoder = _ReasoningTextStreamDecoder()
 
@@ -3343,6 +3427,9 @@ def stream_chat_only(
             for chunk in stream_iter:
                 if stop_event and stop_event.is_set():
                     break
+                response_metadata = getattr(chunk, "response_metadata", None) or {}
+                if isinstance(response_metadata, dict) and response_metadata:
+                    latest_response_metadata.update(response_metadata)
                 parts = decode_ai_stream_parts(chunk, decoder)
                 if not parts and not thinking_signalled:
                     thinking_signalled = True
@@ -3373,6 +3460,9 @@ def stream_chat_only(
             provider_call["mode"] = "invoke"
             _provider_started = time.perf_counter()
             result = llm.invoke(messages)
+            response_metadata = getattr(result, "response_metadata", None) or {}
+            if isinstance(response_metadata, dict) and response_metadata:
+                latest_response_metadata.update(response_metadata)
             phase_timings["generation.provider_invoke_ms"] = (
                 time.perf_counter() - _provider_started
             ) * 1000.0
@@ -3403,6 +3493,7 @@ def stream_chat_only(
     answer = "".join(full_answer)
     provider_done_ms = (time.perf_counter() - _provider_started) * 1000.0
     phase_timings["generation.provider_stream_ms"] = provider_done_ms
+    prompt_cache_usage = normalize_prompt_cache_usage(latest_response_metadata)
     provider_call.update({
         "complete_ms": provider_done_ms,
         "duration_ms": provider_done_ms,
@@ -3410,6 +3501,7 @@ def stream_chat_only(
         "answer_chars": len(answer),
         "reasoning_chunks": len(full_reasoning),
         "reasoning_chars": len("".join(full_reasoning)),
+        **prompt_cache_usage,
     })
     phase_timings["generation.provider_call_count"] = 1
     phase_timings["generation.provider_calls"] = [
@@ -3434,6 +3526,7 @@ def stream_chat_only(
             "answer_chunks": len(full_answer),
             "reasoning_chars": len("".join(full_reasoning)),
             "reasoning_chunks": len(full_reasoning),
+            **prompt_cache_usage,
         },
     )
     additional_kwargs = {"reasoning_content": "".join(full_reasoning)} if full_reasoning else {}
@@ -3445,7 +3538,11 @@ def stream_chat_only(
             thread_id,
             [
                 HumanMessage(content=user_input),
-                AIMessage(content=answer, additional_kwargs=additional_kwargs),
+                AIMessage(
+                    content=answer,
+                    additional_kwargs=additional_kwargs,
+                    response_metadata=latest_response_metadata,
+                ),
             ],
         )
     yield ("done", answer)
@@ -3991,6 +4088,7 @@ def _log_stream_completion(
 ) -> None:
     """Log enough completion detail to diagnose reasoning-only model stops."""
     response_metadata = dict(getattr(latest_ai_message, "response_metadata", None) or {})
+    prompt_cache_usage = normalize_prompt_cache_usage(response_metadata)
     additional_kwargs = getattr(latest_ai_message, "additional_kwargs", None) or {}
     checkpoint_answer_chars = len(_content_to_str(getattr(latest_ai_message, "content", "") or "")) if latest_ai_message else 0
     checkpoint_reasoning_chars = len(str(additional_kwargs.get("reasoning_content") or "")) if latest_ai_message else 0
@@ -4024,6 +4122,8 @@ def _log_stream_completion(
         "prompt_eval_count": response_metadata.get("prompt_eval_count"),
         "total_duration": response_metadata.get("total_duration"),
     })
+    if prompt_cache_usage:
+        diagnostics.update(prompt_cache_usage)
     if (
         not answer_chars
         and not checkpoint_answer_chars
@@ -4272,6 +4372,9 @@ def _stream_graph(agent, input_data, config: dict,
 
             # Track finish_reason from streaming response_metadata
             _rm = getattr(msg, "response_metadata", None) or {}
+            _prompt_cache_usage = normalize_prompt_cache_usage(_rm)
+            if _prompt_cache_usage:
+                provider_call.update(_prompt_cache_usage)
             _fr = _rm.get("finish_reason")
             if _fr:
                 _finish_reason = _fr

--- a/src/row_bot/prompt_cache.py
+++ b/src/row_bot/prompt_cache.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from langchain_core.messages import BaseMessage, SystemMessage
+
+
+ANTHROPIC_CACHE_MARKER: dict[str, str] = {"type": "ephemeral"}
+
+
+@dataclass(frozen=True)
+class PromptCacheMarkerResult:
+    provider_id: str
+    applied: bool
+    marker_count: int
+    eligible_system_count: int
+    stable_fingerprint: str = ""
+    reason: str = ""
+
+
+def content_has_cache_control(content: Any) -> bool:
+    return isinstance(content, list) and any(
+        isinstance(block, dict) and "cache_control" in block
+        for block in content
+    )
+
+
+def _int_value(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _mapping_value(mapping: dict[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = mapping
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _first_int(mapping: dict[str, Any], paths: tuple[tuple[str, ...], ...]) -> int | None:
+    for path in paths:
+        value = _int_value(_mapping_value(mapping, path))
+        if value is not None:
+            return value
+    return None
+
+
+def normalize_prompt_cache_usage(response_metadata: dict[str, Any] | None) -> dict[str, int]:
+    """Return prompt-cache token counts from provider response metadata."""
+    metadata = dict(response_metadata or {})
+    usage = metadata.get("token_usage")
+    if not isinstance(usage, dict):
+        usage = metadata.get("usage")
+    if not isinstance(usage, dict):
+        usage = metadata.get("usage_metadata")
+    if not isinstance(usage, dict):
+        usage = metadata
+
+    read_tokens = _first_int(
+        usage,
+        (
+            ("cache_read_input_tokens",),
+            ("prompt_cache_read_tokens",),
+            ("input_cached_tokens",),
+            ("cached_tokens",),
+            ("input_tokens_details", "cached_tokens"),
+            ("prompt_tokens_details", "cached_tokens"),
+        ),
+    )
+    write_tokens = _first_int(
+        usage,
+        (
+            ("cache_creation_input_tokens",),
+            ("cache_write_input_tokens",),
+            ("prompt_cache_write_tokens",),
+            ("input_cache_creation_tokens",),
+            ("input_tokens_details", "cache_creation_tokens"),
+            ("prompt_tokens_details", "cache_creation_tokens"),
+        ),
+    )
+
+    normalized: dict[str, int] = {}
+    if read_tokens is not None:
+        normalized["prompt_cache_read_tokens"] = read_tokens
+    if write_tokens is not None:
+        normalized["prompt_cache_write_tokens"] = write_tokens
+    return normalized
+
+
+def _with_anthropic_cache_marker(message: SystemMessage) -> SystemMessage:
+    content = message.content
+    if isinstance(content, str):
+        next_content: Any = [
+            {
+                "type": "text",
+                "text": content,
+                "cache_control": dict(ANTHROPIC_CACHE_MARKER),
+            }
+        ]
+    elif isinstance(content, list):
+        next_content = list(content)
+        for index in range(len(next_content) - 1, -1, -1):
+            block = next_content[index]
+            if isinstance(block, dict) and str(block.get("type") or "text") == "text":
+                next_content[index] = {
+                    **block,
+                    "cache_control": dict(ANTHROPIC_CACHE_MARKER),
+                }
+                break
+        else:
+            next_content.append({
+                "type": "text",
+                "text": "",
+                "cache_control": dict(ANTHROPIC_CACHE_MARKER),
+            })
+    else:
+        next_content = [
+            {
+                "type": "text",
+                "text": str(content or ""),
+                "cache_control": dict(ANTHROPIC_CACHE_MARKER),
+            }
+        ]
+
+    try:
+        return message.model_copy(update={"content": next_content})
+    except AttributeError:
+        return message.copy(update={"content": next_content})
+
+
+def apply_anthropic_system_cache_marker(
+    messages: list[BaseMessage],
+    *,
+    provider_id: str | None,
+    cache_eligible_system_message_ids: set[int],
+    stable_fingerprint: str = "",
+) -> tuple[list[BaseMessage], PromptCacheMarkerResult]:
+    provider = str(provider_id or "")
+    eligible_indices = [
+        index
+        for index, message in enumerate(messages)
+        if isinstance(message, SystemMessage) and id(message) in cache_eligible_system_message_ids
+    ]
+    if provider != "anthropic":
+        return list(messages), PromptCacheMarkerResult(
+            provider_id=provider,
+            applied=False,
+            marker_count=0,
+            eligible_system_count=len(eligible_indices),
+            stable_fingerprint=stable_fingerprint,
+            reason="provider_not_anthropic",
+        )
+    if not eligible_indices:
+        return list(messages), PromptCacheMarkerResult(
+            provider_id=provider,
+            applied=False,
+            marker_count=0,
+            eligible_system_count=0,
+            stable_fingerprint=stable_fingerprint,
+            reason="no_cache_eligible_system",
+        )
+
+    target_index = eligible_indices[-1]
+    marked_messages = list(messages)
+    marked_messages[target_index] = _with_anthropic_cache_marker(marked_messages[target_index])
+    return marked_messages, PromptCacheMarkerResult(
+        provider_id=provider,
+        applied=True,
+        marker_count=1,
+        eligible_system_count=len(eligible_indices),
+        stable_fingerprint=stable_fingerprint,
+        reason="stable_system_breakpoint",
+    )

--- a/src/row_bot/prompt_context.py
+++ b/src/row_bot/prompt_context.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from hashlib import sha256
+from typing import Iterable
+
+from langchain_core.messages import SystemMessage
+
+
+class PromptStability(StrEnum):
+    STABLE = "stable"
+    EPHEMERAL = "ephemeral"
+
+
+@dataclass(frozen=True)
+class PromptSection:
+    section_id: str
+    content: str
+    stability: PromptStability
+    cache_eligible: bool = False
+    source: str = ""
+
+    def system_message(self) -> SystemMessage:
+        return SystemMessage(content=self.content)
+
+
+@dataclass(frozen=True)
+class PromptSectionMessage:
+    section: PromptSection
+    message: SystemMessage
+
+
+def stable_section(
+    section_id: str,
+    content: str,
+    *,
+    cache_eligible: bool = True,
+    source: str = "",
+) -> PromptSection | None:
+    text = str(content or "").strip()
+    if not text:
+        return None
+    return PromptSection(
+        section_id=section_id,
+        content=text,
+        stability=PromptStability.STABLE,
+        cache_eligible=cache_eligible,
+        source=source,
+    )
+
+
+def ephemeral_section(section_id: str, content: str, *, source: str = "") -> PromptSection | None:
+    text = str(content or "").strip()
+    if not text:
+        return None
+    return PromptSection(
+        section_id=section_id,
+        content=text,
+        stability=PromptStability.EPHEMERAL,
+        cache_eligible=False,
+        source=source,
+    )
+
+
+def section_messages(sections: Iterable[PromptSection]) -> list[PromptSectionMessage]:
+    return [
+        PromptSectionMessage(section=section, message=section.system_message())
+        for section in sections
+        if section.content
+    ]
+
+
+def cache_eligible_message_ids(section_message_pairs: Iterable[PromptSectionMessage]) -> set[int]:
+    return {
+        id(pair.message)
+        for pair in section_message_pairs
+        if pair.section.stability == PromptStability.STABLE and pair.section.cache_eligible
+    }
+
+
+def stable_prefix_fingerprint(sections: Iterable[PromptSection]) -> str:
+    hasher = sha256()
+    for section in sections:
+        if section.stability != PromptStability.STABLE or not section.cache_eligible:
+            continue
+        hasher.update(section.section_id.encode("utf-8"))
+        hasher.update(b"\0")
+        hasher.update(section.content.encode("utf-8"))
+        hasher.update(b"\0")
+    return hasher.hexdigest()
+
+
+def stable_cache_sections(sections: Iterable[PromptSection]) -> tuple[PromptSection, ...]:
+    return tuple(
+        section
+        for section in sections
+        if section.stability == PromptStability.STABLE and section.cache_eligible
+    )

--- a/src/row_bot/self_knowledge.py
+++ b/src/row_bot/self_knowledge.py
@@ -412,12 +412,8 @@ def get_dynamic_state() -> str:
     return "Current state:\n" + "\n".join(parts) + "\n"
 
 
-def build_self_knowledge_block() -> str:
-    """Assemble the full self-knowledge block for prompt injection.
-
-    Returns a string suitable for inserting as a SystemMessage.
-    Omits skill-improvement guidance when self-improvement is disabled.
-    """
+def build_static_self_knowledge_block() -> str:
+    """Return Row-Bot self-knowledge that is stable across normal turns."""
     sections = [ABOUT_ROW_BOT]
 
     try:
@@ -427,7 +423,23 @@ def build_self_knowledge_block() -> str:
     except Exception:
         sections.append(SKILL_CREATION_GUIDANCE)  # safe fallback: include
 
+    return "\n".join(sections)
+
+
+def build_dynamic_self_knowledge_block() -> str:
+    """Return current Row-Bot runtime state for prompt injection."""
     state = get_dynamic_state()
+    return state or ""
+
+
+def build_self_knowledge_block() -> str:
+    """Assemble the full self-knowledge block for prompt injection.
+
+    Returns a string suitable for inserting as a SystemMessage.
+    Omits skill-improvement guidance when self-improvement is disabled.
+    """
+    sections = [build_static_self_knowledge_block()]
+    state = build_dynamic_self_knowledge_block()
     if state:
         sections.append(state)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,6 +47,10 @@ inventory snapshot.
 `tests/helpers/legacy_inventory.py` verifies that every retired legacy section
 has covered replacement paths. PR and release CI use `scripts/run_test_matrix.py`;
 no substantive coverage should be added back to the legacy script files.
+Prompt assembly changes in `agent.py`, `prompts.py`, `self_knowledge.py`,
+`prompt_context.py`, or `prompt_cache.py` select the subsystem agent tests,
+prompt-cache provider tests, and the focused Chat Only, memory, skills, and
+provider runtime regressions.
 
 `scripts/run_test_matrix.py coverage` runs the migrated contract/subsystem lane
 with `pytest-cov`, writes `.tmp/coverage/migrated-subsystems.xml`, and enforces
@@ -58,6 +62,11 @@ Developer Studio, Designer export, and existing plugin modules.
 Use `python scripts/coverage_summary.py` after a coverage run for a compact
 per-module summary of `.tmp/coverage/migrated-subsystems.xml`.
 
-Live provider, real MCP, and real channel checks stay opt-in. Use the manual
-`.github/workflows/live-e2e.yml` workflow when credentials or external services
-are available.
+Live provider, real MCP, and real channel checks stay opt-in. Live provider
+prompt-cache validation should use the real Row-Bot runtime with at least one
+latest recommended chat-capable model per configured provider. The only
+acceptable provider-side failure is an explicit out-of-credits, quota,
+usage-exhausted, or billing-limit response; schema, auth, routing, streaming,
+tool replay, and unsupported-parameter failures are bugs or blockers. Use the
+manual `.github/workflows/live-e2e.yml` workflow when credentials or external
+services are available.

--- a/tests/e2e/test_live_provider_matrix.py
+++ b/tests/e2e/test_live_provider_matrix.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import time
 from pathlib import Path
 from typing import Any
@@ -14,12 +15,33 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 pytestmark = pytest.mark.live_provider
 
 
-ACCEPTABLE_ERROR_RE = re.compile(
-    r"credit|quota|rate.?limit|insufficient|balance|billing|payment|capacity|"
-    r"not configured|credentials|not_running|connection refused|unable to connect|"
-    r"connection error|timeout|timed out|model unavailable|not found|404",
+OUT_OF_CREDITS_RE = re.compile(
+    r"out of credits|credit(?:s)? exhausted|quota exceeded|usage exhausted|"
+    r"billing limit|insufficient (?:balance|credits|quota)|payment required|"
+    r"account balance|spend limit",
     re.IGNORECASE,
 )
+
+
+FALLBACK_LIVE_MODEL_IDS: dict[str, str] = {
+    "anthropic": "claude-sonnet-4-6",
+    "atlascloud": "anthropic/claude-opus-4.8",
+    "claude_subscription": "claude-sonnet-4-6",
+    "codex": "gpt-5.5",
+    "google": "gemini-3.1-flash-lite-preview",
+    "minimax": "MiniMax-M2.7",
+    "ollama_cloud": "gpt-oss:120b-cloud",
+    "openai": "gpt-5.4",
+    "opencode_go": "qwen3.7-max",
+    "opencode_zen": "kimi-k2.6",
+    "openrouter": "z-ai/glm-5.2",
+    "xai": "grok-4-1-fast-reasoning",
+    "xai_oauth": "grok-4.20-0309-non-reasoning",
+}
+
+
+def _live_data_dir() -> Path:
+    return Path(os.environ.get("ROW_BOT_LIVE_PROVIDER_DATA_DIR") or Path.home() / ".row-bot").expanduser()
 
 
 def _enabled() -> bool:
@@ -28,6 +50,49 @@ def _enabled() -> bool:
 
 def _report_path() -> Path:
     return Path(os.environ.get("ROW_BOT_LIVE_PROVIDER_REPORT", "test-results/live_provider_matrix.json"))
+
+
+def _agent_smoke_candidate_supported(provider_id: str, snapshot: Any) -> bool:
+    if provider_id != "openrouter":
+        return True
+    return isinstance(snapshot, dict) and snapshot.get("tool_calling") is True
+
+
+def _hydrate_live_provider_profile() -> dict[str, Any]:
+    from row_bot import api_keys, secret_store
+    from row_bot.data_paths import get_row_bot_data_dir
+    from row_bot.providers import config as provider_config
+    from row_bot.providers.auth_store import PROVIDER_API_KEY_ENV
+
+    live_dir = _live_data_dir()
+    test_data_dir = get_row_bot_data_dir()
+    live_service = secret_store.service_name_for(live_dir)
+    live_provider_config = provider_config.load_provider_config(live_dir / "providers.json")
+    provider_config.save_provider_config(live_provider_config)
+    copied_cache_files: list[str] = []
+    for filename in ("cloud_models_cache.json", "context_catalog_cache.json", "model_catalog_cache.json"):
+        source = live_dir / filename
+        if not source.exists():
+            continue
+        destination = test_data_dir / filename
+        if source.resolve() == destination.resolve():
+            continue
+        shutil.copyfile(source, destination)
+        copied_cache_files.append(filename)
+    loaded_env_keys: list[str] = []
+    for env_var in sorted(set(PROVIDER_API_KEY_ENV.values())):
+        value = api_keys.get_key_for_data_dir(live_dir, env_var)
+        if not value:
+            continue
+        os.environ[env_var] = value
+        loaded_env_keys.append(env_var)
+    secret_store.SERVICE_NAME = live_service
+    return {
+        "loaded_api_key_envs": loaded_env_keys,
+        "copied_cache_files": copied_cache_files,
+        "copied_quick_choices": len(live_provider_config.get("quick_choices") or []),
+        "copied_custom_endpoints": len(live_provider_config.get("custom_endpoints") or []),
+    }
 
 
 def _event_summary(events: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -129,6 +194,8 @@ def _poison_thread(thread_id: str) -> None:
 
 
 def _run_poisoned_case(agent_module, *, model_ref: str, provider_id: str) -> dict[str, Any]:
+    from row_bot.threads import get_latest_checkpoint_messages
+
     thread_id = f"live_{provider_id}_poison_{int(time.time() * 1000)}"
     _poison_thread(thread_id)
     config = {"configurable": {"thread_id": thread_id, "model_override": model_ref, "runtime_mode": "agent"}}
@@ -146,10 +213,10 @@ def _run_poisoned_case(agent_module, *, model_ref: str, provider_id: str) -> dic
             "thinking_chars": 0,
             "event_types": [],
         }
-    diagnostics_before = agent_module._provider_transcript_diagnostics(__import__("threads").get_latest_checkpoint_messages(thread_id))
+    diagnostics_before = agent_module._provider_transcript_diagnostics(get_latest_checkpoint_messages(thread_id))
     diagnostics_after = agent_module._provider_transcript_diagnostics(
         agent_module._normalize_provider_facing_messages(
-            __import__("threads").get_latest_checkpoint_messages(thread_id),
+            get_latest_checkpoint_messages(thread_id),
             provider_id=provider_id,
         )
     )
@@ -177,6 +244,11 @@ def _discover_live_candidates() -> list[dict[str, str]]:
         model_id = str(choice.get("model_id") or "")
         if not provider_id or not model_id or provider_id not in configured:
             continue
+        if provider_id == "openrouter" and model_id != FALLBACK_LIVE_MODEL_IDS["openrouter"]:
+            continue
+        snapshot = choice.get("capabilities_snapshot") if isinstance(choice.get("capabilities_snapshot"), dict) else {}
+        if not _agent_smoke_candidate_supported(provider_id, snapshot):
+            continue
         status = provider_status(provider_id)
         if not status.get("configured"):
             continue
@@ -186,6 +258,29 @@ def _discover_live_candidates() -> list[dict[str, str]]:
             "model_id": model_id,
             "display_name": str(choice.get("display_name") or model_id),
         })
+
+    for provider_id in sorted(configured):
+        if provider_id in candidates:
+            continue
+        model_id = FALLBACK_LIVE_MODEL_IDS.get(provider_id)
+        if not model_id:
+            continue
+        status = provider_status(provider_id)
+        if not status.get("configured"):
+            continue
+        if provider_id == "openrouter":
+            from row_bot.models import _cloud_model_cache
+
+            cached = _cloud_model_cache.get(model_ref(provider_id, model_id)) or _cloud_model_cache.get(model_id)
+            snapshot = cached.get("capabilities_snapshot") if isinstance(cached, dict) and isinstance(cached.get("capabilities_snapshot"), dict) else {}
+            if not _agent_smoke_candidate_supported(provider_id, snapshot):
+                continue
+        candidates[provider_id] = {
+            "provider_id": provider_id,
+            "model_ref": model_ref(provider_id, model_id),
+            "model_id": model_id,
+            "display_name": model_id,
+        }
 
     for endpoint in list_custom_endpoints():
         provider_id = str(endpoint.get("provider_id") or "")
@@ -213,18 +308,21 @@ def _classify_result(case: dict[str, Any]) -> str:
     if case.get("status") == "done" and case.get("answer_chars", 0) > 0:
         return "pass"
     text = " ".join(str(error) for error in case.get("errors") or [])
-    if ACCEPTABLE_ERROR_RE.search(text):
+    if OUT_OF_CREDITS_RE.search(text):
         return "acceptable_error"
     return "unexpected_error"
 
 
 @pytest.mark.skipif(not _enabled(), reason="set ROW_BOT_LIVE_PROVIDER_E2E=1 to run real provider calls")
 def test_live_configured_provider_matrix():
+    os.environ.pop("ROW_BOT_TEST_MODE", None)
+    profile = _hydrate_live_provider_profile()
     import row_bot.agent as agent
 
     candidates = _discover_live_candidates()
     report: dict[str, Any] = {
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "profile": profile,
         "candidates": candidates,
         "providers": [],
     }

--- a/tests/helpers/source_test_map.py
+++ b/tests/helpers/source_test_map.py
@@ -23,6 +23,28 @@ class SourceTestRule:
 
 SOURCE_TEST_RULES: tuple[SourceTestRule, ...] = (
     SourceTestRule(
+        "prompt_context",
+        (
+            "src/row_bot/agent.py",
+            "src/row_bot/prompts.py",
+            "src/row_bot/self_knowledge.py",
+            "src/row_bot/prompt_context.py",
+            "src/row_bot/prompt_cache.py",
+        ),
+        (
+            "tests/subsystem/agents",
+            "tests/subsystem/providers/test_prompt_cache_payloads.py",
+            "tests/subsystem/providers/test_prompt_cache_metrics.py",
+            "tests/test_provider_runtime.py",
+            "tests/test_chat_only_runtime.py",
+            "tests/test_agent_runtime_profiles.py",
+            "tests/test_memory_recall_uplift.py",
+            "tests/test_skills_activation.py",
+            "tests/test_slash_commands.py",
+        ),
+        "Prompt assembly changes need stable/ephemeral context, provider cache marker, Chat Only, memory, and skill regressions.",
+    ),
+    SourceTestRule(
         "providers",
         ("src/row_bot/providers/**", "src/row_bot/tools/image_gen_tool.py", "src/row_bot/tools/video_gen_tool.py"),
         (

--- a/tests/subsystem/agents/test_prompt_context_builder.py
+++ b/tests/subsystem/agents/test_prompt_context_builder.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+
+def test_stable_prefix_fingerprint_ignores_ephemeral_sections_and_tracks_stable_changes():
+    from row_bot.prompt_context import ephemeral_section, stable_prefix_fingerprint, stable_section
+
+    base_sections = [
+        stable_section("agent.root", "root prompt"),
+        stable_section("platform.context", "windows powershell"),
+        ephemeral_section("turn.date_time", "Tuesday"),
+    ]
+    changed_ephemeral = [
+        stable_section("agent.root", "root prompt"),
+        stable_section("platform.context", "windows powershell"),
+        ephemeral_section("turn.date_time", "Wednesday"),
+    ]
+    changed_stable = [
+        stable_section("agent.root", "root prompt"),
+        stable_section("platform.context", "macos zsh"),
+        ephemeral_section("turn.date_time", "Tuesday"),
+    ]
+
+    assert stable_prefix_fingerprint(section for section in base_sections if section is not None)
+    assert stable_prefix_fingerprint(section for section in base_sections if section is not None) == stable_prefix_fingerprint(
+        section for section in changed_ephemeral if section is not None
+    )
+    assert stable_prefix_fingerprint(section for section in base_sections if section is not None) != stable_prefix_fingerprint(
+        section for section in changed_stable if section is not None
+    )
+
+
+def test_section_messages_track_cache_eligible_stable_systems_only():
+    from row_bot.prompt_context import cache_eligible_message_ids, ephemeral_section, section_messages, stable_section
+
+    pairs = section_messages(section for section in [
+        stable_section("agent.root", "root prompt"),
+        stable_section("agent.disabled_cache", "stable but not cached", cache_eligible=False),
+        ephemeral_section("turn.date_time", "Tuesday"),
+    ] if section is not None)
+
+    eligible_ids = cache_eligible_message_ids(pairs)
+
+    assert id(pairs[0].message) in eligible_ids
+    assert id(pairs[1].message) not in eligible_ids
+    assert id(pairs[2].message) not in eligible_ids

--- a/tests/subsystem/agents/test_prompt_context_stability.py
+++ b/tests/subsystem/agents/test_prompt_context_stability.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+
+def _fresh_agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / "data"))
+    import row_bot.agent as agent
+
+    return importlib.reload(agent)
+
+
+def _message_text(message) -> str:
+    content = getattr(message, "content", "")
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                parts.append(str(block.get("text") or block.get("thinking") or block.get("data") or ""))
+            else:
+                parts.append(str(block))
+        return "\n".join(parts)
+    return str(content)
+
+
+def _has_cache_control(message) -> bool:
+    content = getattr(message, "content", "")
+    return isinstance(content, list) and any(
+        isinstance(block, dict) and "cache_control" in block
+        for block in content
+    )
+
+
+def _marked_messages(messages) -> list[tuple[str, str]]:
+    return [
+        (getattr(message, "type", ""), _message_text(message))
+        for message in messages
+        if _has_cache_control(message)
+    ]
+
+
+def test_anthropic_cache_markers_stay_on_stable_system_context_only(tmp_path, monkeypatch):
+    agent = _fresh_agent(tmp_path, monkeypatch)
+
+    decision = SimpleNamespace(
+        allowed=True,
+        reason="selected",
+        candidates_seen=1,
+        selected=[{
+            "id": "mem_dynamic",
+            "entity_type": "fact",
+            "subject": "Dynamic Memory",
+            "description": "DYNAMIC_RECALL_SENTINEL",
+            "score": 0.9,
+        }],
+        trace={},
+    )
+
+    monkeypatch.setattr(agent, "get_context_size", lambda: 200_000)
+    monkeypatch.setattr(agent, "trim_messages", lambda messages, **kwargs: list(messages))
+    monkeypatch.setattr(agent, "get_current_model", lambda: "model:anthropic:claude-sonnet-4-5")
+    monkeypatch.setattr(agent, "is_cloud_model", lambda model: True)
+    monkeypatch.setattr(agent, "get_cloud_provider", lambda model: "anthropic")
+    monkeypatch.setattr(agent, "is_background_workflow", lambda: False)
+    monkeypatch.setattr(agent, "_agent_runtime_system_context", lambda: "RUNTIME_DYNAMIC_SENTINEL")
+    monkeypatch.setattr("row_bot.prompts.get_platform_context", lambda: "PLATFORM_STABLE_SENTINEL")
+    monkeypatch.setattr("row_bot.self_knowledge.build_static_self_knowledge_block", lambda: "SELF_STATIC_SENTINEL")
+    monkeypatch.setattr("row_bot.self_knowledge.build_dynamic_self_knowledge_block", lambda: "DYNAMIC_STATE_SENTINEL")
+    monkeypatch.setattr("row_bot.skills.get_skills_prompt", lambda *args, **kwargs: "")
+    monkeypatch.setattr("row_bot.plugins.registry.get_skills_prompt", lambda: "")
+    monkeypatch.setattr("row_bot.memory_policy.build_auto_recall", lambda *args, **kwargs: decision)
+    monkeypatch.setattr("row_bot.memory_policy.touch_selected_memories", lambda recall_decision: None)
+    monkeypatch.setattr("row_bot.memory_policy.record_recall_trace", lambda recall_decision, **kwargs: None)
+
+    agent._set_active_runtime_context(thread_id="cache-stability", enabled_tool_names=())
+    agent.set_active_model_override("model:anthropic:claude-sonnet-4-5")
+    try:
+        result = agent._pre_model_trim({
+            "messages": [
+                SystemMessage(content="ROOT_STABLE_SENTINEL"),
+                HumanMessage(content="first turn"),
+                AIMessage(content="first answer"),
+                HumanMessage(content="second turn"),
+            ]
+        })["llm_input_messages"]
+    finally:
+        agent.set_active_model_override("")
+
+    marked = _marked_messages(result)
+
+    assert marked, "Anthropic should receive at least one cache breakpoint"
+    assert all(message_type == "system" for message_type, _text in marked)
+    assert any(
+        any(stable_sentinel in text for stable_sentinel in (
+            "ROOT_STABLE_SENTINEL",
+            "PLATFORM_STABLE_SENTINEL",
+            "SELF_STATIC_SENTINEL",
+        ))
+        for _message_type, text in marked
+    )
+    for dynamic_sentinel in (
+        "Current date and time:",
+        "RUNTIME_DYNAMIC_SENTINEL",
+        "DYNAMIC_STATE_SENTINEL",
+        "DYNAMIC_RECALL_SENTINEL",
+        "first turn",
+        "second turn",
+    ):
+        assert all(dynamic_sentinel not in text for _message_type, text in marked)
+
+
+def test_chat_only_prompt_uses_stable_chat_contract_without_agent_runtime_context(tmp_path, monkeypatch):
+    agent = _fresh_agent(tmp_path, monkeypatch)
+
+    monkeypatch.setattr("row_bot.threads.get_latest_checkpoint_messages", lambda thread_id: [])
+    monkeypatch.setattr(agent, "trim_messages", lambda messages, **kwargs: list(messages))
+    monkeypatch.setattr(agent, "_agent_runtime_system_context", lambda: "RUNTIME_DYNAMIC_SENTINEL")
+    monkeypatch.setattr("row_bot.self_knowledge.build_static_self_knowledge_block", lambda: "SELF_STATIC_SENTINEL")
+    monkeypatch.setattr("row_bot.self_knowledge.build_dynamic_self_knowledge_block", lambda: "DYNAMIC_STATE_SENTINEL")
+
+    messages = agent._build_chat_only_messages("chat-stability", "hello", context_window=4096)
+    system_text = "\n".join(_message_text(message) for message in messages if message.type == "system")
+
+    assert "Do not answer an imagined or unrelated task" in system_text
+    assert "tools are not available here" in system_text
+    assert "RUNTIME_DYNAMIC_SENTINEL" not in system_text
+    assert "DYNAMIC_STATE_SENTINEL" not in system_text

--- a/tests/subsystem/providers/test_prompt_cache_metrics.py
+++ b/tests/subsystem/providers/test_prompt_cache_metrics.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from langchain_core.messages import AIMessage
+
+
+def test_prompt_cache_usage_normalizes_anthropic_and_openai_shapes():
+    from row_bot.prompt_cache import normalize_prompt_cache_usage
+
+    assert normalize_prompt_cache_usage({
+        "token_usage": {
+            "cache_read_input_tokens": 12,
+            "cache_creation_input_tokens": 34,
+        }
+    }) == {
+        "prompt_cache_read_tokens": 12,
+        "prompt_cache_write_tokens": 34,
+    }
+
+    assert normalize_prompt_cache_usage({
+        "token_usage": {
+            "input_tokens_details": {"cached_tokens": "56"},
+            "prompt_tokens_details": {"cache_creation_tokens": 78},
+        }
+    }) == {
+        "prompt_cache_read_tokens": 56,
+        "prompt_cache_write_tokens": 78,
+    }
+
+
+def test_stream_completion_diagnostics_log_prompt_cache_counts_without_prompt_text(monkeypatch, caplog):
+    import row_bot.agent as agent
+
+    monkeypatch.setattr(agent, "get_current_model", lambda: "model:anthropic:claude-sonnet-4-5")
+    monkeypatch.setattr(agent, "get_context_size", lambda model=None: 200_000)
+    monkeypatch.setattr(
+        "row_bot.providers.resolution.resolve_provider_config",
+        lambda *args, **kwargs: SimpleNamespace(
+            provider_id="anthropic",
+            runtime_model="claude-sonnet-4-5",
+            selection_ref="model:anthropic:claude-sonnet-4-5",
+        ),
+    )
+
+    latest = AIMessage(
+        content="ok",
+        response_metadata={
+            "token_usage": {
+                "cache_read_input_tokens": 12,
+                "cache_creation_input_tokens": 34,
+            },
+            "debug_prompt_text": "SECRET_PROMPT_TEXT",
+        },
+    )
+
+    with caplog.at_level(logging.INFO, logger="row_bot.agent"):
+        agent._log_stream_completion(
+            config={"configurable": {"thread_id": "thread-cache", "model_override": "model:anthropic:claude-sonnet-4-5"}},
+            answer_chars=2,
+            answer_chunks=1,
+            reasoning_chars=0,
+            reasoning_chunks=0,
+            tool_call_count=0,
+            tool_result_count=0,
+            finish_reason="stop",
+            stopped_by_user=False,
+            loop_detected=False,
+            browser_budget_exceeded=False,
+            latest_ai_message=latest,
+            phase_timings=None,
+        )
+
+    record = next(
+        record for record in caplog.records
+        if record.name == "row_bot.agent" and record.message.startswith("stream completion diagnostics=")
+    )
+    diagnostics = record.args[0] if isinstance(record.args, tuple) else record.args
+    assert diagnostics["prompt_cache_read_tokens"] == 12
+    assert diagnostics["prompt_cache_write_tokens"] == 34
+    assert "SECRET_PROMPT_TEXT" not in record.message

--- a/tests/subsystem/providers/test_prompt_cache_payloads.py
+++ b/tests/subsystem/providers/test_prompt_cache_payloads.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import HumanMessage, SystemMessage
+
+
+def _fresh_agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / "data"))
+    import row_bot.agent as agent
+
+    return importlib.reload(agent)
+
+
+def _has_cache_control(message) -> bool:
+    content = getattr(message, "content", "")
+    return isinstance(content, list) and any(
+        isinstance(block, dict) and "cache_control" in block
+        for block in content
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider_id", "model_id", "uses_anthropic_messages"),
+    [
+        ("minimax", "MiniMax-M2.7", True),
+        ("opencode_zen", "anthropic/claude-sonnet-4-5", True),
+        ("opencode_go", "anthropic/claude-sonnet-4-5", True),
+        ("claude_subscription", "claude-sonnet-4-5", True),
+        ("codex", "gpt-5.5", False),
+        ("xai_oauth", "grok-4", False),
+        ("openai", "gpt-5.5", False),
+        ("openrouter", "anthropic/claude-sonnet-4-5", False),
+        ("custom_openai_lab", "local-chat", False),
+        ("atlascloud", "anthropic/claude-sonnet-4-5", False),
+    ],
+)
+def test_prompt_cache_markers_are_provider_gated(
+    tmp_path,
+    monkeypatch,
+    provider_id: str,
+    model_id: str,
+    uses_anthropic_messages: bool,
+):
+    agent = _fresh_agent(tmp_path, monkeypatch)
+    model_ref = f"model:{provider_id}:{model_id}"
+    decision = SimpleNamespace(
+        allowed=False,
+        reason="disabled",
+        candidates_seen=0,
+        selected=[],
+        trace={},
+    )
+
+    monkeypatch.setattr(agent, "get_context_size", lambda: 65_536)
+    monkeypatch.setattr(agent, "trim_messages", lambda messages, **kwargs: list(messages))
+    monkeypatch.setattr(agent, "get_current_model", lambda: model_ref)
+    monkeypatch.setattr(agent, "is_cloud_model", lambda model: True)
+    monkeypatch.setattr(agent, "get_cloud_provider", lambda model: provider_id)
+    monkeypatch.setattr(agent, "is_background_workflow", lambda: False)
+    monkeypatch.setattr(
+        agent,
+        "_provider_uses_anthropic_messages",
+        lambda pid, _model_id=None: bool(uses_anthropic_messages and pid == provider_id),
+    )
+    monkeypatch.setattr("row_bot.self_knowledge.build_static_self_knowledge_block", lambda: "SELF_SENTINEL")
+    monkeypatch.setattr("row_bot.self_knowledge.build_dynamic_self_knowledge_block", lambda: "")
+    monkeypatch.setattr("row_bot.skills.get_skills_prompt", lambda *args, **kwargs: "")
+    monkeypatch.setattr("row_bot.plugins.registry.get_skills_prompt", lambda: "")
+    monkeypatch.setattr("row_bot.memory_policy.build_auto_recall", lambda *args, **kwargs: decision)
+    monkeypatch.setattr("row_bot.memory_policy.touch_selected_memories", lambda recall_decision: None)
+    monkeypatch.setattr("row_bot.memory_policy.record_recall_trace", lambda recall_decision, **kwargs: None)
+
+    agent._set_active_runtime_context(thread_id=f"cache-{provider_id}", enabled_tool_names=())
+    agent.set_active_model_override(model_ref)
+    try:
+        result = agent._pre_model_trim({
+            "messages": [
+                SystemMessage(content="ROOT_SENTINEL"),
+                HumanMessage(content="hello"),
+            ]
+        })["llm_input_messages"]
+    finally:
+        agent.set_active_model_override("")
+
+    assert not any(_has_cache_control(message) for message in result)

--- a/tests/subsystem/test_source_test_map.py
+++ b/tests/subsystem/test_source_test_map.py
@@ -52,6 +52,25 @@ def test_memory_tool_change_selects_tool_and_graph_coverage() -> None:
     assert "tests/test_memory_recall_uplift.py" in selection.test_paths
 
 
+def test_prompt_context_change_selects_prompt_and_provider_regressions() -> None:
+    selection = select_tests_for_changes([
+        "src/row_bot/agent.py",
+        "src/row_bot/prompts.py",
+        "src/row_bot/self_knowledge.py",
+        "src/row_bot/prompt_context.py",
+        "src/row_bot/prompt_cache.py",
+    ])
+
+    assert "prompt_context" in selection.matched_rules
+    assert "tests/subsystem/agents" in selection.test_paths
+    assert "tests/subsystem/providers/test_prompt_cache_payloads.py" in selection.test_paths
+    assert "tests/subsystem/providers/test_prompt_cache_metrics.py" in selection.test_paths
+    assert "tests/test_provider_runtime.py" in selection.test_paths
+    assert "tests/test_chat_only_runtime.py" in selection.test_paths
+    assert "tests/test_memory_recall_uplift.py" in selection.test_paths
+    assert not selection.unmatched_files
+
+
 def test_updater_change_selects_updater_and_installer_contracts() -> None:
     selection = select_tests_for_changes(["src/row_bot/updater.py"])
 

--- a/tests/test_developer_studio_phase10.py
+++ b/tests/test_developer_studio_phase10.py
@@ -494,7 +494,8 @@ def test_developer_context_is_hidden_system_context():
     assert "agent_input = f\"{developer_context}" not in streaming_source
     assert '"developer_context": developer_context' in streaming_source
     assert "_developer_context_var" in agent_source
-    assert "SystemMessage(content=developer_context)" in agent_source
+    assert '"turn.developer_context"' in agent_source
+    assert "ephemeral_section" in agent_source
 
 
 def test_developer_patch_rejects_path_traversal(tmp_path, monkeypatch):

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -1133,7 +1133,8 @@ def test_custom_openai_pre_model_trim_compacts_32k_agent_payload(tmp_path, monke
     import row_bot.skills as skills
     import row_bot.plugins.registry as plugin_registry
 
-    monkeypatch.setattr(self_knowledge, "build_self_knowledge_block", lambda: "SELF_SENTINEL " * 1000)
+    monkeypatch.setattr(self_knowledge, "build_static_self_knowledge_block", lambda: "SELF_SENTINEL " * 1000)
+    monkeypatch.setattr(self_knowledge, "build_dynamic_self_knowledge_block", lambda: "SELF_DYNAMIC_SENTINEL " * 1000)
     monkeypatch.setattr(skills, "get_skills_prompt", lambda *args, **kwargs: "SKILL_SENTINEL " * 1000)
     monkeypatch.setattr(plugin_registry, "get_skills_prompt", lambda: "PLUGIN_SENTINEL " * 1000)
 
@@ -1658,7 +1659,8 @@ def test_openai_pre_model_trim_keeps_standard_skill_injections(tmp_path, monkeyp
     import row_bot.skills as skills
     import row_bot.plugins.registry as plugin_registry
 
-    monkeypatch.setattr(self_knowledge, "build_self_knowledge_block", lambda: "SELF_SENTINEL")
+    monkeypatch.setattr(self_knowledge, "build_static_self_knowledge_block", lambda: "SELF_SENTINEL")
+    monkeypatch.setattr(self_knowledge, "build_dynamic_self_knowledge_block", lambda: "")
     monkeypatch.setattr(skills, "get_skills_prompt", lambda *args, **kwargs: "SKILL_SENTINEL")
     monkeypatch.setattr(plugin_registry, "get_skills_prompt", lambda: "PLUGIN_SENTINEL")
 


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [x] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [x] Agent / prompts / tools
- [ ] Designer
- [x] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `uv run python scripts/run_test_matrix.py fast`
- [x] I ran `uv run python scripts/run_test_matrix.py pr` for shared, release-sensitive, or cross-subsystem changes
- [x] I added or updated tests
- [x] I updated the relevant inventory in `tests/helpers/` when changing coverage ownership
- [x] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [x] User-visible change, release notes needed
- [ ] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
