### PR TITLE
Add natural interactive progress updates

### DIFF
--- a/src/row_bot/agent.py
+++ b/src/row_bot/agent.py
@@ -831,6 +831,37 @@ def _agent_runtime_system_context() -> str:
         f"Approval mode for action-capable tools: {get_approval_mode()}. "
         f"{tool_line}"
     )
+
+
+def _interactive_progress_contract(runtime_surface: str) -> str:
+    """Return progress-update guidance for interactive streamed agent turns."""
+    selected_mode = str(_current_selected_runtime_mode_var.get("") or "")
+    surface = str(runtime_surface or "").strip()
+    if selected_mode != "agent":
+        return ""
+    if is_background_workflow():
+        return ""
+    if surface == "channel" and not _current_channel_streaming_var.get(False):
+        return ""
+    if surface not in {"normal_chat", "designer", "developer", "channel"}:
+        return ""
+
+    parts = [
+        "INTERACTIVE PROGRESS:",
+        "For interactive work that will take multiple tool calls or more than a few seconds, "
+        "stream occasional short user-facing progress updates before or between meaningful phases.",
+        "Write them naturally in your own voice. Do not use a fixed template, do not narrate "
+        "every tool call, and do not mention low-level tool names unless the user needs that detail.",
+        "Never reveal hidden reasoning, private secrets, raw logs, or unapproved content.",
+        "Skip progress updates for quick answers. Keep the final answer focused on results and "
+        "avoid repeating the live updates.",
+    ]
+    if surface == "channel":
+        parts.append(
+            "For channel conversations, keep progress updates especially sparse because message "
+            "edits may notify the user."
+        )
+    return "\n".join(parts)
 # Extra tokens to account for content injected by _pre_model_trim that is NOT
 # stored in the checkpoint: skills prompt, date/time line, auto-recalled
 # memories, per-message framing tokens.
@@ -1579,6 +1610,16 @@ def _pre_model_trim(state: dict) -> dict:
     except Exception:
         pass
 
+    progress_contract = _interactive_progress_contract(_current_runtime_surface_var.get(""))
+    if progress_contract:
+        _section = ephemeral_section(
+            "turn.interactive_progress",
+            progress_contract,
+            source="agent",
+        )
+        if _section is not None:
+            _ephemeral_injection_sections.append(_section)
+
     # Background-mode override
     if is_background_workflow():
         from row_bot.prompts import AGENT_BG_OVERRIDE
@@ -2045,6 +2086,9 @@ _current_agent_profile_snapshot_var: _contextvars.ContextVar[dict] = _contextvar
 _current_tool_allowlist_var: _contextvars.ContextVar[tuple[str, ...]] = _contextvars.ContextVar(
     "current_tool_allowlist", default=()
 )
+_current_channel_streaming_var: _contextvars.ContextVar[bool] = _contextvars.ContextVar(
+    "current_channel_streaming", default=False
+)
 
 
 def get_current_thread_id() -> str:
@@ -2068,6 +2112,7 @@ def get_active_runtime_context() -> dict:
         "enabled_tool_names": tuple(_current_enabled_tool_names_var.get(()) or ()),
         "tool_allowlist": tuple(_current_tool_allowlist_var.get(()) or ()),
         "agent_profile_id": _current_agent_profile_id_var.get(""),
+        "channel_streaming": bool(_current_channel_streaming_var.get(False)),
     }
 
 
@@ -2085,6 +2130,7 @@ def _set_active_runtime_context(
     tool_allowlist: list[str] | tuple[str, ...] | None = None,
     agent_profile_id: str = "",
     agent_profile_snapshot: dict | None = None,
+    channel_streaming: bool = False,
 ) -> None:
     _current_thread_id_var.set(thread_id or "")
     _current_runtime_surface_var.set(runtime_surface or "")
@@ -2098,6 +2144,7 @@ def _set_active_runtime_context(
     _current_tool_allowlist_var.set(tuple(tool_allowlist or ()))
     _current_agent_profile_id_var.set(agent_profile_id or "")
     _current_agent_profile_snapshot_var.set(dict(agent_profile_snapshot or {}))
+    _current_channel_streaming_var.set(bool(channel_streaming))
 
 
 def _agent_profile_system_context(thread_id: str = "") -> str:
@@ -3051,6 +3098,7 @@ def invoke_agent(user_input: str, enabled_tool_names: list[str], config: dict,
         tool_allowlist=_tool_allowlist,
         agent_profile_id=str(configurable.get("agent_profile_id") or ""),
         agent_profile_snapshot=configurable.get("agent_profile_snapshot") or {},
+        channel_streaming=bool(configurable.get("channel_streaming")),
     )
     _developer_context_var.set(
         configurable.get("developer_context", "") or ""
@@ -3456,6 +3504,7 @@ def stream_chat_only(
         enabled_tool_names=(),
         agent_profile_id=str(configurable.get("agent_profile_id") or ""),
         agent_profile_snapshot=configurable.get("agent_profile_snapshot") or {},
+        channel_streaming=bool(configurable.get("channel_streaming")),
     )
     set_active_model_override(model_label)
     _readiness_started = time.perf_counter()
@@ -3687,6 +3736,7 @@ def stream_agent(user_input: str, enabled_tool_names: list[str], config: dict,
         tool_allowlist=_tool_allowlist,
         agent_profile_id=str(configurable.get("agent_profile_id") or ""),
         agent_profile_snapshot=configurable.get("agent_profile_snapshot") or {},
+        channel_streaming=bool(configurable.get("channel_streaming")),
     )
     auto_allowed = runtime_mode == "auto" and runtime_surface in {"normal_chat", "channel"}
     if runtime_mode == "chat_only" or auto_allowed:
@@ -3781,6 +3831,7 @@ def stream_agent(user_input: str, enabled_tool_names: list[str], config: dict,
         tool_allowlist=_tool_allowlist,
         agent_profile_id=str(configurable.get("agent_profile_id") or ""),
         agent_profile_snapshot=configurable.get("agent_profile_snapshot") or {},
+        channel_streaming=bool(configurable.get("channel_streaming")),
     )
     _developer_context_var.set(
         (config.get("configurable") or {}).get("developer_context", "") or ""
@@ -3903,6 +3954,7 @@ def resume_stream_agent(enabled_tool_names: list[str], config: dict, approved: b
         tool_allowlist=_tool_allowlist,
         agent_profile_id=str(configurable.get("agent_profile_id") or ""),
         agent_profile_snapshot=configurable.get("agent_profile_snapshot") or {},
+        channel_streaming=bool(configurable.get("channel_streaming")),
     )
     _developer_context_var.set(
         configurable.get("developer_context", "") or ""
@@ -3951,6 +4003,7 @@ def resume_invoke_agent(enabled_tool_names: list[str], config: dict, approved: b
         tool_allowlist=_tool_allowlist,
         agent_profile_id=str(configurable.get("agent_profile_id") or ""),
         agent_profile_snapshot=configurable.get("agent_profile_snapshot") or {},
+        channel_streaming=bool(configurable.get("channel_streaming")),
     )
     _developer_context_var.set(
         configurable.get("developer_context", "") or ""

--- a/src/row_bot/channels/agent_output.py
+++ b/src/row_bot/channels/agent_output.py
@@ -1,0 +1,15 @@
+"""Helpers for assembling channel-facing agent output."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def assemble_agent_answer(answer: str, tool_reports: Sequence[str]) -> str:
+    """Return final channel text, favoring the model's answer over tool logs."""
+    if str(answer or "").strip():
+        return answer
+    reports = [str(report) for report in tool_reports if str(report).strip()]
+    if reports:
+        return "\n".join(reports)
+    return ""

--- a/src/row_bot/channels/discord_channel.py
+++ b/src/row_bot/channels/discord_channel.py
@@ -123,6 +123,7 @@ def build_channel_runtime_config(config: dict, purpose: str) -> dict:
             **(config.get("configurable") or {}),
             "runtime_surface": runtime_surface,
             "runtime_mode": runtime_mode,
+            "channel_streaming": purpose != "approval",
             "approval_mode": approval_mode_for_config(config),
         },
     }
@@ -170,11 +171,9 @@ def _run_agent_sync(user_text: str, config: dict,
         if event_queue is not None:
             event_queue.put((event_type, payload))
 
-    answer = "".join(full_answer)
-    if tool_reports and answer:
-        answer = "\n".join(tool_reports) + "\n\n" + answer
-    elif tool_reports:
-        answer = "\n".join(tool_reports)
+    from row_bot.channels.agent_output import assemble_agent_answer
+
+    answer = assemble_agent_answer("".join(full_answer), tool_reports)
 
     if event_queue is not None:
         event_queue.put(None)  # sentinel
@@ -236,11 +235,9 @@ def _resume_agent_sync(config: dict, approved: bool,
             if payload and not full_answer:
                 full_answer.append(payload)
 
-    answer = "".join(full_answer)
-    if tool_reports and answer:
-        answer = "\n".join(tool_reports) + "\n\n" + answer
-    elif tool_reports:
-        answer = "\n".join(tool_reports)
+    from row_bot.channels.agent_output import assemble_agent_answer
+
+    answer = assemble_agent_answer("".join(full_answer), tool_reports)
 
     captured_images: list[bytes] = []
     captured_video_paths: list[str] = []

--- a/src/row_bot/channels/slack.py
+++ b/src/row_bot/channels/slack.py
@@ -168,6 +168,7 @@ def build_channel_runtime_config(config: dict, purpose: str) -> dict:
             **(config.get("configurable") or {}),
             "runtime_surface": runtime_surface,
             "runtime_mode": runtime_mode,
+            "channel_streaming": purpose != "approval",
             "approval_mode": approval_mode_for_config(config),
         },
     }
@@ -216,11 +217,9 @@ def _run_agent_sync(user_text: str, config: dict,
         if event_queue is not None:
             event_queue.put((event_type, payload))
 
-    answer = "".join(full_answer)
-    if tool_reports and answer:
-        answer = "\n".join(tool_reports) + "\n\n" + answer
-    elif tool_reports:
-        answer = "\n".join(tool_reports)
+    from row_bot.channels.agent_output import assemble_agent_answer
+
+    answer = assemble_agent_answer("".join(full_answer), tool_reports)
 
     if event_queue is not None:
         event_queue.put(None)  # sentinel
@@ -282,11 +281,9 @@ def _resume_agent_sync(config: dict, approved: bool,
             if payload and not full_answer:
                 full_answer.append(payload)
 
-    answer = "".join(full_answer)
-    if tool_reports and answer:
-        answer = "\n".join(tool_reports) + "\n\n" + answer
-    elif tool_reports:
-        answer = "\n".join(tool_reports)
+    from row_bot.channels.agent_output import assemble_agent_answer
+
+    answer = assemble_agent_answer("".join(full_answer), tool_reports)
 
     captured_images: list[bytes] = []
     captured_video_paths: list[str] = []

--- a/src/row_bot/channels/sms.py
+++ b/src/row_bot/channels/sms.py
@@ -163,6 +163,7 @@ def build_channel_runtime_config(config: dict, purpose: str) -> dict:
             **(config.get("configurable") or {}),
             "runtime_surface": runtime_surface,
             "runtime_mode": runtime_mode,
+            "channel_streaming": False,
             "approval_mode": approval_mode_for_config(config),
         },
     }

--- a/src/row_bot/channels/telegram.py
+++ b/src/row_bot/channels/telegram.py
@@ -203,6 +203,7 @@ def build_channel_runtime_config(config: dict, purpose: str) -> dict:
             **(config.get("configurable") or {}),
             "runtime_surface": runtime_surface,
             "runtime_mode": runtime_mode,
+            "channel_streaming": purpose != "approval",
             "approval_mode": approval_mode_for_config(config),
         },
     }
@@ -255,11 +256,9 @@ def _run_agent_sync(user_text: str, config: dict,
         if event_queue is not None:
             event_queue.put((event_type, payload))
 
-    answer = "".join(full_answer)
-    if tool_reports and answer:
-        answer = "\n".join(tool_reports) + "\n\n" + answer
-    elif tool_reports:
-        answer = "\n".join(tool_reports)
+    from row_bot.channels.agent_output import assemble_agent_answer
+
+    answer = assemble_agent_answer("".join(full_answer), tool_reports)
 
     if event_queue is not None:
         event_queue.put(None)  # sentinel
@@ -318,11 +317,9 @@ def _resume_agent_sync(config: dict, approved: bool,
             if payload and not full_answer:
                 full_answer.append(payload)
 
-    answer = "".join(full_answer)
-    if tool_reports and answer:
-        answer = "\n".join(tool_reports) + "\n\n" + answer
-    elif tool_reports:
-        answer = "\n".join(tool_reports)
+    from row_bot.channels.agent_output import assemble_agent_answer
+
+    answer = assemble_agent_answer("".join(full_answer), tool_reports)
 
     captured_images: list[bytes] = []
     captured_video_paths: list[str] = []

--- a/src/row_bot/channels/whatsapp.py
+++ b/src/row_bot/channels/whatsapp.py
@@ -427,6 +427,7 @@ def build_channel_runtime_config(config: dict, purpose: str) -> dict:
             **(config.get("configurable") or {}),
             "runtime_surface": runtime_surface,
             "runtime_mode": runtime_mode,
+            "channel_streaming": purpose != "approval",
             "approval_mode": approval_mode_for_config(config),
         },
     }
@@ -477,11 +478,9 @@ def _run_agent_sync(user_text: str, config: dict,
     if event_queue is not None:
         event_queue.put(None)  # sentinel
 
-    answer = "".join(full_answer)
-    if tool_reports and answer:
-        answer = "\n".join(tool_reports) + "\n\n" + answer
-    elif tool_reports:
-        answer = "\n".join(tool_reports)
+    from row_bot.channels.agent_output import assemble_agent_answer
+
+    answer = assemble_agent_answer("".join(full_answer), tool_reports)
 
     captured_images: list[bytes] = []
     captured_video_paths: list[str] = []
@@ -540,11 +539,9 @@ def _resume_agent_sync(config: dict, approved: bool,
             if payload and not full_answer:
                 full_answer.append(payload)
 
-    answer = "".join(full_answer)
-    if tool_reports and answer:
-        answer = "\n".join(tool_reports) + "\n\n" + answer
-    elif tool_reports:
-        answer = "\n".join(tool_reports)
+    from row_bot.channels.agent_output import assemble_agent_answer
+
+    answer = assemble_agent_answer("".join(full_answer), tool_reports)
 
     captured_images: list[bytes] = []
     captured_video_paths: list[str] = []

--- a/src/row_bot/designer/prompt.py
+++ b/src/row_bot/designer/prompt.py
@@ -96,7 +96,10 @@ def _mode_guidelines(mode: str) -> str:
             "  (b) split content to an additional page via designer_add_page.\n"
             "  Never ship a document with an unresolved overflow finding.\n"
             "- After the tool calls, give a one- or two-sentence chat summary of\n"
-            "  what you wrote — never repeat the full document body in chat.\n"
+            "  what you wrote or changed; never repeat the full document body in\n"
+            "  chat. Brief live progress updates while inspecting, editing,\n"
+            "  rendering, or validating are allowed, but keep them concise and\n"
+            "  do not paste document/page body content into chat.\n"
         )
     if m == "storyboard":
         return (

--- a/tests/subsystem/agents/test_interactive_progress_contract.py
+++ b/tests/subsystem/agents/test_interactive_progress_contract.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+
+def _fresh_agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / "data"))
+    import row_bot.agent as agent
+
+    return importlib.reload(agent)
+
+
+def _quiet_prompt_dependencies(agent, monkeypatch) -> None:
+    decision = SimpleNamespace(
+        allowed=False,
+        reason="disabled_for_test",
+        candidates_seen=0,
+        selected=[],
+        trace={},
+    )
+    monkeypatch.setattr(agent, "get_context_size", lambda *args, **kwargs: 200_000)
+    monkeypatch.setattr(agent, "trim_messages", lambda messages, **kwargs: list(messages))
+    monkeypatch.setattr("row_bot.prompts.get_platform_context", lambda: "")
+    monkeypatch.setattr("row_bot.self_knowledge.build_static_self_knowledge_block", lambda: "")
+    monkeypatch.setattr("row_bot.self_knowledge.build_dynamic_self_knowledge_block", lambda: "")
+    monkeypatch.setattr("row_bot.skills.get_skills_prompt", lambda *args, **kwargs: "")
+    monkeypatch.setattr("row_bot.plugins.registry.get_skills_prompt", lambda: "")
+    monkeypatch.setattr("row_bot.memory_policy.build_auto_recall", lambda *args, **kwargs: decision)
+    monkeypatch.setattr("row_bot.memory_policy.record_recall_trace", lambda *args, **kwargs: None)
+    monkeypatch.setattr("row_bot.memory_policy.touch_selected_memories", lambda *args, **kwargs: None)
+
+
+def _prompt_for(agent, *, surface: str, selected_mode: str = "agent", channel_streaming: bool = False) -> str:
+    agent._set_active_runtime_context(
+        thread_id=f"progress-{surface}-{selected_mode}",
+        runtime_surface=surface,
+        requested_runtime_mode="agent",
+        selected_runtime_mode=selected_mode,
+        enabled_tool_names=[],
+        channel_streaming=channel_streaming,
+    )
+    result = agent._pre_model_trim({
+        "messages": [
+            SystemMessage(content="Base system"),
+            HumanMessage(content="Please do a multi-step check."),
+        ]
+    })
+    return "\n".join(
+        str(getattr(message, "content", ""))
+        for message in result["llm_input_messages"]
+        if getattr(message, "type", "") == "system"
+    )
+
+
+def test_interactive_progress_contract_is_injected_for_interactive_agent_surfaces(tmp_path, monkeypatch):
+    agent = _fresh_agent(tmp_path, monkeypatch)
+    _quiet_prompt_dependencies(agent, monkeypatch)
+
+    for surface in ("normal_chat", "designer", "developer"):
+        prompt = _prompt_for(agent, surface=surface)
+        assert "INTERACTIVE PROGRESS:" in prompt
+        assert "stream occasional short user-facing progress updates" in prompt
+        assert "do not narrate every tool call" in prompt
+
+
+def test_streaming_channel_gets_sparse_progress_contract(tmp_path, monkeypatch):
+    agent = _fresh_agent(tmp_path, monkeypatch)
+    _quiet_prompt_dependencies(agent, monkeypatch)
+
+    prompt = _prompt_for(agent, surface="channel", channel_streaming=True)
+
+    assert "INTERACTIVE PROGRESS:" in prompt
+    assert "keep progress updates especially sparse" in prompt
+
+
+def test_progress_contract_is_omitted_for_noninteractive_or_nonstreaming_paths(tmp_path, monkeypatch):
+    agent = _fresh_agent(tmp_path, monkeypatch)
+    _quiet_prompt_dependencies(agent, monkeypatch)
+
+    assert "INTERACTIVE PROGRESS:" not in _prompt_for(agent, surface="approval")
+    assert "INTERACTIVE PROGRESS:" not in _prompt_for(
+        agent,
+        surface="normal_chat",
+        selected_mode="chat_only",
+    )
+    assert "INTERACTIVE PROGRESS:" not in _prompt_for(
+        agent,
+        surface="channel",
+        channel_streaming=False,
+    )
+
+    token = agent._background_workflow_var.set(True)
+    try:
+        prompt = _prompt_for(agent, surface="normal_chat")
+    finally:
+        agent._background_workflow_var.reset(token)
+    assert "INTERACTIVE PROGRESS:" not in prompt

--- a/tests/subsystem/designer/test_designer_prompt_contract.py
+++ b/tests/subsystem/designer/test_designer_prompt_contract.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from row_bot.designer.prompt import build_designer_prompt
+from row_bot.designer.state import DesignerProject
+
+
+def test_document_prompt_allows_brief_progress_without_repeating_body() -> None:
+    project = DesignerProject(name="Document Prompt Contract", mode="document")
+
+    prompt = build_designer_prompt(project)
+
+    assert "Brief live progress updates" in prompt
+    assert "inspecting, editing" in prompt
+    assert "never repeat the full document body in" in prompt
+    assert "do not paste document/page body content into chat" in prompt
+    assert "designer_set_pages" in prompt
+    assert "designer_update_page" in prompt

--- a/tests/test_channel_streaming.py
+++ b/tests/test_channel_streaming.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 import queue
 
 
@@ -88,3 +89,36 @@ def test_telegram_stream_consumer_returns_none_when_final_edit_fails():
     assert result is None
     assert edits[0] == "first"
     assert any("complete" in edit for edit in edits)
+
+
+def test_channel_final_answer_prefers_model_text_over_tool_reports():
+    from row_bot.channels.agent_output import assemble_agent_answer
+
+    answer = assemble_agent_answer("Here is the answer.", ["Using Search...", "Search done"])
+
+    assert answer == "Here is the answer."
+
+
+def test_channel_final_answer_falls_back_to_tool_reports_without_model_text():
+    from row_bot.channels.agent_output import assemble_agent_answer
+
+    answer = assemble_agent_answer("  ", ["Using Search...", "Search done"])
+
+    assert answer == "Using Search...\nSearch done"
+
+
+def test_channel_runtime_marks_stream_capable_adapters_and_leaves_sms_nonstreaming():
+    streaming_paths = [
+        "src/row_bot/channels/telegram.py",
+        "src/row_bot/channels/slack.py",
+        "src/row_bot/channels/discord_channel.py",
+        "src/row_bot/channels/whatsapp.py",
+    ]
+    for path in streaming_paths:
+        source = Path(path).read_text(encoding="utf-8")
+        assert '"channel_streaming": purpose != "approval"' in source
+        assert "assemble_agent_answer" in source
+
+    sms_source = Path("src/row_bot/channels/sms.py").read_text(encoding="utf-8")
+    assert '"channel_streaming": False' in sms_source
+    assert "assemble_agent_answer" not in sms_source


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [x] Agent / prompts / tools
- [x] Designer
- [ ] Memory / knowledge graph
- [x] Channels / external integrations
- [ ] Installers / auto-update
- [x] UI only
- [ ] Other

## Testing

- [x] I ran `uv run python scripts/run_test_matrix.py fast`
- [x] I ran `uv run python scripts/run_test_matrix.py pr` for shared, release-sensitive, or cross-subsystem changes
- [x] I added or updated tests
- [x] I updated the relevant inventory in `tests/helpers/` when changing coverage ownership
- [x] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [x] User-visible change, release notes needed
- [ ] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
