### PR TITLE
fix(ui): move sidebar pin toggle before actions

### DIFF
--- a/src/row_bot/ui/sidebar.py
+++ b/src/row_bot/ui/sidebar.py
@@ -875,11 +875,6 @@ def build_sidebar(
                 with ui.item(on_click=_select).classes(item_classes).props(
                     "clickable" + (" active" if is_active else "")
                 ).style(item_style):
-                    with ui.item_section().props("avatar").style("min-width: 28px;"):
-                        _render_pin_toggle_button(
-                            is_pinned=is_pinned,
-                            on_click=lambda t=tid, pinned=not is_pinned: _pin(t, pinned),
-                        )
                     with ui.item_section():
                         with ui.row().classes("items-center no-wrap gap-1").style(
                             "min-width: 0; max-width: 100%;"
@@ -893,31 +888,36 @@ def build_sidebar(
                                 "font-size: 0.7rem;"
                             )
                     with ui.item_section().props("side"):
-                        action_btn = ui.button(icon="more_vert").props("flat dense round size=xs color=grey-6")
-                        action_btn.on("click", js_handler="(e) => e.stopPropagation()")
-                        with action_btn:
-                            with ui.menu() as action_menu:
-                                _render_pin_menu_item(
-                                    label="Unpin" if is_pinned else "Pin",
-                                    icon="push_pin",
-                                    on_click=lambda t=tid, pinned=not is_pinned: _pin(t, pinned),
-                                    menu=action_menu,
-                                )
-                                ui.separator()
-                                _render_action_menu_item(
-                                    label="Rename",
-                                    icon="edit",
-                                    on_click=lambda t=tid, n=name: _rename(t, n),
-                                    menu=action_menu,
-                                )
-                                ui.separator()
-                                _render_action_menu_item(
-                                    label="Delete",
-                                    icon="delete",
-                                    on_click=lambda t=tid: _delete(t),
-                                    menu=action_menu,
-                                    icon_classes="text-negative",
-                                )
+                        with ui.row().classes("items-center no-wrap gap-1"):
+                            _render_pin_toggle_button(
+                                is_pinned=is_pinned,
+                                on_click=lambda t=tid, pinned=not is_pinned: _pin(t, pinned),
+                            )
+                            action_btn = ui.button(icon="more_vert").props("flat dense round size=xs color=grey-6")
+                            action_btn.on("click", js_handler="(e) => e.stopPropagation()")
+                            with action_btn:
+                                with ui.menu() as action_menu:
+                                    _render_pin_menu_item(
+                                        label="Unpin" if is_pinned else "Pin",
+                                        icon="push_pin",
+                                        on_click=lambda t=tid, pinned=not is_pinned: _pin(t, pinned),
+                                        menu=action_menu,
+                                    )
+                                    ui.separator()
+                                    _render_action_menu_item(
+                                        label="Rename",
+                                        icon="edit",
+                                        on_click=lambda t=tid, n=name: _rename(t, n),
+                                        menu=action_menu,
+                                    )
+                                    ui.separator()
+                                    _render_action_menu_item(
+                                        label="Delete",
+                                        icon="delete",
+                                        on_click=lambda t=tid: _delete(t),
+                                        menu=action_menu,
+                                        icon_classes="text-negative",
+                                    )
 
             if len(threads) > SIDEBAR_MAX_THREADS:
                 def _show_all():
@@ -1244,33 +1244,38 @@ def build_sidebar(
                                                     ui.item_label(_fmt_ts(updated)).props("caption")
                                             if not bulk.active:
                                                 with ui.item_section().props("side"):
-                                                    action_btn = ui.button(icon="more_vert").props(
-                                                        "flat dense round size=xs color=grey-6"
-                                                    )
-                                                    action_btn.on("click", js_handler="(e) => e.stopPropagation()")
-                                                    with action_btn:
-                                                        with ui.menu() as action_menu:
-                                                            _render_pin_menu_item(
-                                                                label="Unpin" if is_pinned else "Pin",
-                                                                icon="push_pin",
-                                                                on_click=lambda t=tid, pinned=not is_pinned: _pin_modal(t, pinned),
-                                                                menu=action_menu,
-                                                            )
-                                                            ui.separator()
-                                                            _render_action_menu_item(
-                                                                label="Rename",
-                                                                icon="edit",
-                                                                on_click=lambda t=tid, n=name: _ren(t, n),
-                                                                menu=action_menu,
-                                                            )
-                                                            ui.separator()
-                                                            _render_action_menu_item(
-                                                                label="Delete",
-                                                                icon="delete",
-                                                                on_click=lambda t=tid: _del(t),
-                                                                menu=action_menu,
-                                                                icon_classes="text-negative",
-                                                            )
+                                                    with ui.row().classes("items-center no-wrap gap-1"):
+                                                        _render_pin_toggle_button(
+                                                            is_pinned=is_pinned,
+                                                            on_click=lambda t=tid, pinned=not is_pinned: _pin_modal(t, pinned),
+                                                        )
+                                                        action_btn = ui.button(icon="more_vert").props(
+                                                            "flat dense round size=xs color=grey-6"
+                                                        )
+                                                        action_btn.on("click", js_handler="(e) => e.stopPropagation()")
+                                                        with action_btn:
+                                                            with ui.menu() as action_menu:
+                                                                _render_pin_menu_item(
+                                                                    label="Unpin" if is_pinned else "Pin",
+                                                                    icon="push_pin",
+                                                                    on_click=lambda t=tid, pinned=not is_pinned: _pin_modal(t, pinned),
+                                                                    menu=action_menu,
+                                                                )
+                                                                ui.separator()
+                                                                _render_action_menu_item(
+                                                                    label="Rename",
+                                                                    icon="edit",
+                                                                    on_click=lambda t=tid, n=name: _ren(t, n),
+                                                                    menu=action_menu,
+                                                                )
+                                                                ui.separator()
+                                                                _render_action_menu_item(
+                                                                    label="Delete",
+                                                                    icon="delete",
+                                                                    on_click=lambda t=tid: _del(t),
+                                                                    menu=action_menu,
+                                                                    icon_classes="text-negative",
+                                                                )
 
                         action_slot = ui.column().classes("w-full")
 

--- a/tests/test_thread_pinning.py
+++ b/tests/test_thread_pinning.py
@@ -243,29 +243,34 @@ def test_sidebar_and_all_conversations_pin_affordances_are_wired():
     assert "_rebuild_thread_list_ref[0]()" not in pin_modal_block
 
 
-def test_sidebar_uses_left_slot_for_interactive_thread_pin_toggle():
+def test_sidebar_places_interactive_thread_pin_toggle_before_action_menu():
     source = (ROOT / "src" / "row_bot" / "ui" / "sidebar.py").read_text(encoding="utf-8")
     list_block = source.split("def _rebuild_thread_list()", 1)[1].split(
         "if len(threads) > SIDEBAR_MAX_THREADS:",
         1,
     )[0]
-    sidebar_thread_block = list_block.split("with ui.item(on_click=_select)", 1)[1].split(
+    sidebar_thread_block = list_block.split("with ui.item(on_click=_select)", 1)[1]
+    thread_main_block, thread_side_block = sidebar_thread_block.split(
         'with ui.item_section().props("side")',
         1,
-    )[0]
+    )
 
     assert '"folder_open" if is_expanded else "folder"' in list_block
     assert "row-bot-thread-row" in list_block
-    assert "_render_pin_toggle_button(" in sidebar_thread_block
-    assert "is_pinned=is_pinned" in sidebar_thread_block
-    assert "pinned=not is_pinned" in sidebar_thread_block
+    assert "_render_pin_toggle_button(" not in thread_main_block
+    assert "_render_pin_toggle_button(" in thread_side_block
+    assert "is_pinned=is_pinned" in thread_side_block
+    assert "pinned=not is_pinned" in thread_side_block
+    assert thread_side_block.index("_render_pin_toggle_button(") < thread_side_block.index(
+        'ui.button(icon="more_vert")'
+    )
     assert "row-bot-pin-toggle-unpinned" in source
     assert "row-bot-thread-row:hover .row-bot-pin-toggle-unpinned" in source
     assert "row-bot-thread-row:focus-within .row-bot-pin-toggle-unpinned" in source
-    assert "_thr_icon" not in sidebar_thread_block
-    assert 'ui.icon("computer"' not in sidebar_thread_block
-    assert 'ui.icon("cloud"' not in sidebar_thread_block
-    assert 'ui.icon("code"' not in sidebar_thread_block
+    assert "_thr_icon" not in thread_main_block
+    assert 'ui.icon("computer"' not in thread_main_block
+    assert 'ui.icon("cloud"' not in thread_main_block
+    assert 'ui.icon("code"' not in thread_main_block
     assert "_render_pinned_thread_icon" not in source
 
 


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [x] UI only
- [ ] Other

## Testing

- [x] I ran `uv run python scripts/run_test_matrix.py fast`
- [x] I ran `uv run python scripts/run_test_matrix.py pr` for shared, release-sensitive, or cross-subsystem changes
- [x] I added or updated tests
- [x] I updated the relevant inventory in `tests/helpers/` when changing coverage ownership
- [x] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [x] User-visible change, release notes needed
- [ ] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
