### PR TITLE
fix(launcher): force visible macOS tray content

### DIFF
--- a/src/row_bot/launcher.py
+++ b/src/row_bot/launcher.py
@@ -481,6 +481,8 @@ class _PystrayTrayBackend:
 
 _MAC_MENU_ITEM_SELECTOR = b"activateMenuItem:"
 _MAC_STATUS_ITEM_DELEGATE_CLASS = None
+_MAC_STATUS_ITEM_FALLBACK_TITLE = "RB"
+_MAC_STATUS_ITEM_MIN_LENGTH = 44.0
 
 
 def _mac_status_item_delegate_class(Foundation, objc):
@@ -518,7 +520,7 @@ class _MacStatusItemBackend:
         self._app = AppKit.NSApplication.sharedApplication()
         self._status_bar = AppKit.NSStatusBar.systemStatusBar()
         self._status_item = self._status_bar.statusItemWithLength_(
-            AppKit.NSVariableStatusItemLength
+            _MAC_STATUS_ITEM_MIN_LENGTH
         )
         if self._status_item is None:
             raise RuntimeError("AppKit did not return an NSStatusItem")
@@ -542,10 +544,17 @@ class _MacStatusItemBackend:
             logger.debug("Could not set macOS tray activation policy", exc_info=True)
 
         self._status_item.setMenu_(self._menu)
+        self._set_status_item_length_on_main()
+        self._set_button_fallback_title_on_main()
         self._set_icon_on_main(self._icon)
         self._set_title_on_main(self._title)
         self._set_visible_on_main(False)
-        _launch_event("tray_status_item_created", backend=self.backend_name, visible=False)
+        _launch_event(
+            "tray_status_item_created",
+            backend=self.backend_name,
+            visible=False,
+            status="text_fallback",
+        )
         _launch_event("tray_backend_ready", backend=self.backend_name)
 
     def _create_menu(self, menu_entries: tuple[_TrayMenuEntry, ...]):
@@ -591,6 +600,10 @@ class _MacStatusItemBackend:
         thickness = max(18, min(32, thickness))
         return (thickness, thickness)
 
+    def _status_item_length(self) -> float:
+        width, _height = self._status_icon_size()
+        return max(_MAC_STATUS_ITEM_MIN_LENGTH, float(width + 22))
+
     def _to_nsimage(self, image):
         from PIL import Image as PILImage
 
@@ -606,6 +619,17 @@ class _MacStatusItemBackend:
     def _set_icon_on_main(self, image) -> None:
         self._nsimage = self._to_nsimage(image)
         self._button.setImage_(self._nsimage)
+        if hasattr(self._button, "setImagePosition_"):
+            image_left = getattr(self._AppKit, "NSImageLeft", 2)
+            self._button.setImagePosition_(image_left)
+
+    def _set_button_fallback_title_on_main(self) -> None:
+        if hasattr(self._button, "setTitle_"):
+            self._button.setTitle_(_MAC_STATUS_ITEM_FALLBACK_TITLE)
+
+    def _set_status_item_length_on_main(self) -> None:
+        if hasattr(self._status_item, "setLength_"):
+            self._status_item.setLength_(self._status_item_length())
 
     def _set_title_on_main(self, value: str) -> None:
         if hasattr(self._button, "setToolTip_"):
@@ -638,6 +662,8 @@ class _MacStatusItemBackend:
         self._schedule_on_main(self._set_title_on_main, value)
 
     def run(self, setup: Callable[[object], None] | None = None) -> None:
+        self._set_status_item_length_on_main()
+        self._set_button_fallback_title_on_main()
         self._set_visible_on_main(True)
         _launch_event("tray_status_item_visible", backend=self.backend_name, visible=True)
         if setup is not None:

--- a/tests/test_startup_hardening.py
+++ b/tests/test_startup_hardening.py
@@ -481,9 +481,17 @@ def _install_fake_appkit(monkeypatch, events, setup_ready: threading.Event | Non
             self.images = []
             self.tooltips = []
             self.hidden = None
+            self.title = ""
+            self.image_positions = []
 
         def setImage_(self, image):
             self.images.append(image)
+
+        def setImagePosition_(self, value):
+            self.image_positions.append(value)
+
+        def setTitle_(self, value):
+            self.title = value
 
         def setToolTip_(self, value):
             self.tooltips.append(value)
@@ -496,6 +504,7 @@ def _install_fake_appkit(monkeypatch, events, setup_ready: threading.Event | Non
             self.button_obj = FakeButton()
             self.menu = None
             self.visible_values = []
+            self.length_values = []
 
         def button(self):
             return self.button_obj
@@ -506,6 +515,10 @@ def _install_fake_appkit(monkeypatch, events, setup_ready: threading.Event | Non
         def setVisible_(self, visible):
             self.visible_values.append(visible)
             events.append(("visible", visible))
+
+        def setLength_(self, length):
+            self.length_values.append(length)
+            events.append(("length", length))
 
     class FakeStatusBar:
         def __init__(self):
@@ -594,6 +607,7 @@ def _install_fake_appkit(monkeypatch, events, setup_ready: threading.Event | Non
     fake_appkit.NSStatusBar = SimpleNamespace(systemStatusBar=lambda: fake_status_bar)
     fake_appkit.NSVariableStatusItemLength = -1
     fake_appkit.NSApplicationActivationPolicyAccessory = 1
+    fake_appkit.NSImageLeft = 2
     fake_appkit.NSMenu = FakeMenu
     fake_appkit.NSMenuItem = FakeMenuItem
     fake_appkit.NSImage = FakeNSImage
@@ -637,6 +651,10 @@ def test_macos_native_status_item_is_visible_before_launcher_startup(monkeypatch
     assert isinstance(tray._icon, launcher._MacStatusItemBackend)
     assert fake.app.run_called
     assert fake.status_bar.status_item.visible_values == [False, True]
+    assert fake.status_bar.status_item.length_values
+    assert all(value >= launcher._MAC_STATUS_ITEM_MIN_LENGTH for value in fake.status_bar.status_item.length_values)
+    assert fake.status_bar.status_item.button_obj.title == "RB"
+    assert fake.status_bar.status_item.button_obj.images
     assert ("tray_status_item_visible", {"backend": "appkit", "visible": True}) in events
     assert events.index(("visible", True)) < events.index("startup")
 


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [x] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [x] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `uv run python scripts/run_test_matrix.py fast`
- [x] I ran `uv run python scripts/run_test_matrix.py pr` for shared, release-sensitive, or cross-subsystem changes
- [x] I added or updated tests
- [x] I updated the relevant inventory in `tests/helpers/` when changing coverage ownership
- [x] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
