### PR TITLE
fix(ui): restore sidebar active thread spinner

### DIFF
--- a/src/row_bot/ui/sidebar.py
+++ b/src/row_bot/ui/sidebar.py
@@ -57,6 +57,17 @@ _SIDEBAR_AVATAR_CSS = """
   min-height: 24px;
   transition: opacity 120ms ease, color 120ms ease;
 }
+.row-bot-thread-row .row-bot-thread-activity-slot {
+  width: 18px;
+  min-width: 18px;
+  padding-right: 0;
+  align-items: center;
+}
+.row-bot-thread-row .row-bot-thread-activity-spinner {
+  width: 14px;
+  height: 14px;
+  min-width: 14px;
+}
 .row-bot-thread-row .row-bot-pin-toggle-unpinned {
   opacity: 0;
 }
@@ -98,6 +109,11 @@ def _thread_row_is_pinned(row: tuple) -> bool:
 
 def _thread_row_updated_at(row: tuple) -> str:
     return str(row[3] or "") if len(row) > 3 else ""
+
+
+def _thread_has_active_generation(thread_id: str) -> bool:
+    gen = _active_generations.get(thread_id)
+    return bool(gen and str(getattr(gen, "status", "") or "").lower() == "streaming")
 
 
 def _sort_classified_thread_rows(
@@ -177,6 +193,17 @@ def _render_pin_toggle_button(
         + ("row-bot-pin-toggle-pinned" if is_pinned else "row-bot-pin-toggle-unpinned")
     ).tooltip(label)
     btn.on("click", js_handler="(e) => e.stopPropagation()")
+
+
+def _render_thread_activity_indicator(label: str) -> None:
+    with ui.item_section().props("avatar").classes("row-bot-thread-activity-slot").style(
+        "width: 18px; min-width: 18px; padding-right: 0;"
+    ):
+        spinner = ui.spinner("oval", size="xs", color="primary").classes(
+            "row-bot-thread-activity-spinner"
+        )
+        spinner.props(f'role="status" aria-label="{label}"')
+        spinner.tooltip(label)
 
 
 def _render_action_menu_item(
@@ -748,6 +775,15 @@ def build_sidebar(
                 name = name or ""
                 is_active = tid == state.thread_id
                 is_pinned = _thread_row_is_pinned(row)
+                is_running = tid in running_tids
+                is_generating_tid = _thread_has_active_generation(tid)
+                activity_label = (
+                    "Generating response"
+                    if is_generating_tid
+                    else "Running workflow"
+                    if is_running
+                    else ""
+                )
 
                 async def _select(t=tid, n=name, mo=_thread_model_ov, pid=_thread_project_id, dev_ws=_dev_workspace_id, app_mode=_thread_approval_mode):
                     from row_bot.ui.voice_lifecycle import stop_voice_for_thread_change
@@ -885,6 +921,8 @@ def build_sidebar(
                 with ui.item(on_click=_select).classes(item_classes).props(
                     "clickable" + (" active" if is_active else "")
                 ).style(item_style):
+                    if activity_label:
+                        _render_thread_activity_indicator(activity_label)
                     with ui.item_section():
                         with ui.row().classes("items-center no-wrap gap-1").style(
                             "min-width: 0; max-width: 100%;"

--- a/tests/test_thread_pinning.py
+++ b/tests/test_thread_pinning.py
@@ -4,6 +4,7 @@ import importlib
 import sqlite3
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -272,6 +273,51 @@ def test_sidebar_places_interactive_thread_pin_toggle_before_action_menu():
     assert 'ui.icon("cloud"' not in thread_main_block
     assert 'ui.icon("code"' not in thread_main_block
     assert "_render_pinned_thread_icon" not in source
+
+
+def test_sidebar_places_active_thread_spinner_left_of_thread_title():
+    source = (ROOT / "src" / "row_bot" / "ui" / "sidebar.py").read_text(encoding="utf-8")
+    list_block = source.split("def _rebuild_thread_list()", 1)[1].split(
+        "if len(threads) > SIDEBAR_MAX_THREADS:",
+        1,
+    )[0]
+    sidebar_thread_block = list_block.split("with ui.item(on_click=_select)", 1)[1]
+    thread_main_block, thread_side_block = sidebar_thread_block.split(
+        'with ui.item_section().props("side")',
+        1,
+    )
+
+    assert "_thread_has_active_generation(tid)" in list_block
+    assert "is_running = tid in running_tids" in list_block
+    assert "row-bot-thread-activity-slot" in source
+    assert "row-bot-thread-activity-spinner" in source
+    assert 'ui.spinner("oval", size="xs", color="primary")' in source
+    assert "_render_thread_activity_indicator(activity_label)" in thread_main_block
+    assert thread_main_block.index("_render_thread_activity_indicator(activity_label)") < thread_main_block.index(
+        "ui.item_label(name)"
+    )
+    assert "_render_pin_toggle_button(" not in thread_main_block
+    assert "_render_pin_toggle_button(" in thread_side_block
+
+
+def test_sidebar_active_generation_indicator_only_tracks_streaming_status():
+    from row_bot.ui import sidebar
+    from row_bot.ui.state import _active_generations
+
+    previous = dict(_active_generations)
+    try:
+        _active_generations.clear()
+        _active_generations["streaming"] = SimpleNamespace(status="streaming")
+        _active_generations["done"] = SimpleNamespace(status="done")
+        _active_generations["stopped"] = SimpleNamespace(status="stopped")
+
+        assert sidebar._thread_has_active_generation("streaming") is True
+        assert sidebar._thread_has_active_generation("done") is False
+        assert sidebar._thread_has_active_generation("stopped") is False
+        assert sidebar._thread_has_active_generation("missing") is False
+    finally:
+        _active_generations.clear()
+        _active_generations.update(previous)
 
 
 def test_sidebar_developer_groups_keep_pinned_children_inside_project_folders():


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [x] UI only
- [ ] Other

## Testing

- [x] I ran `uv run python scripts/run_test_matrix.py fast`
- [x] I ran `uv run python scripts/run_test_matrix.py pr` for shared, release-sensitive, or cross-subsystem changes
- [x] I added or updated tests
- [x] I updated the relevant inventory in `tests/helpers/` when changing coverage ownership
- [x] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
