### PR TITLE
fix: let Stop abort stalled cloud-provider streams

### DIFF
--- a/src/row_bot/providers/runtime.py
+++ b/src/row_bot/providers/runtime.py
@@ -321,6 +321,7 @@ def create_chat_model(model_name: str, provider_id: str | None = None):
             )
         if transport == "openai_responses" or transport.value == "openai_responses":
             from langchain_openai import ChatOpenAI
+            from row_bot.providers.transports.cancellable_http import cancellable_http_client
 
             return ChatOpenAI(
                 model=model_name,
@@ -328,14 +329,17 @@ def create_chat_model(model_name: str, provider_id: str | None = None):
                 base_url=opencode_base_url(provider),
                 use_responses_api=True,
                 output_version="responses/v1",
+                http_client=cancellable_http_client(),
             )
         if transport == "anthropic_messages" or transport.value == "anthropic_messages":
             from langchain_anthropic import ChatAnthropic
+            from row_bot.providers.transports.cancellable_http import cancellable_http_client
 
             return ChatAnthropic(
                 model=model_name,
                 api_key=api_key,
                 base_url=opencode_anthropic_base_url(provider),
+                http_client=cancellable_http_client(),
             )
         raise OpenCodeUnsupportedRouteError(
             f"OpenCode route for {provider_label} model '{model_name}' uses unsupported/deferred transport {transport.value}."
@@ -351,11 +355,13 @@ def create_chat_model(model_name: str, provider_id: str | None = None):
         api_key = api_key or "not-needed"
         if endpoint.get("transport") == "openai_responses":
             from langchain_openai import ChatOpenAI
+            from row_bot.providers.transports.cancellable_http import cancellable_http_client
 
             kwargs = {
                 "model": model_name,
                 "api_key": api_key,
                 "base_url": endpoint["base_url"],
+                "http_client": cancellable_http_client(),
             }
             headers = endpoint.get("headers")
             if isinstance(headers, dict) and headers:
@@ -400,19 +406,21 @@ def create_chat_model(model_name: str, provider_id: str | None = None):
         return ChatXAIOAuthResponses(model_name=model_name)
     if provider == "openai":
         from langchain_openai import ChatOpenAI
+        from row_bot.providers.transports.cancellable_http import cancellable_http_client
         api_key = get_provider_secret("openai")
         if not api_key:
             raise ValueError("OpenAI API key not configured. Set it in Settings → Providers.")
-        kwargs = {"model": model_name, "api_key": api_key}
+        kwargs = {"model": model_name, "api_key": api_key, "http_client": cancellable_http_client()}
         if openai_model_uses_responses_api(model_name):
             kwargs.update({"use_responses_api": True, "output_version": "responses/v1"})
         return ChatOpenAI(**kwargs)
     if provider == "anthropic":
         from langchain_anthropic import ChatAnthropic
+        from row_bot.providers.transports.cancellable_http import cancellable_http_client
         api_key = get_provider_secret("anthropic")
         if not api_key:
             raise ValueError("Anthropic API key not configured. Set it in Settings → Providers.")
-        return ChatAnthropic(model=model_name, api_key=api_key)
+        return ChatAnthropic(model=model_name, api_key=api_key, http_client=cancellable_http_client())
     if provider == "google":
         from langchain_google_genai import ChatGoogleGenerativeAI
         api_key = get_provider_secret("google")
@@ -421,12 +429,14 @@ def create_chat_model(model_name: str, provider_id: str | None = None):
         return ChatGoogleGenerativeAI(model=model_name, google_api_key=api_key)
     if provider == "xai":
         from langchain_xai import ChatXAI
+        from row_bot.providers.transports.cancellable_http import cancellable_http_client
         api_key = get_provider_secret("xai")
         if not api_key:
             raise ValueError("xAI API key not configured. Set it in Settings → Providers.")
-        return ChatXAI(model=model_name, api_key=api_key)
+        return ChatXAI(model=model_name, api_key=api_key, http_client=cancellable_http_client())
     if provider == "minimax":
         from langchain_anthropic import ChatAnthropic
+        from row_bot.providers.transports.cancellable_http import cancellable_http_client
         api_key = get_provider_secret("minimax")
         if not api_key:
             raise ValueError("MiniMax API key not configured. Set it in Settings → Providers.")
@@ -436,6 +446,7 @@ def create_chat_model(model_name: str, provider_id: str | None = None):
             model=model_name,
             api_key=api_key,
             base_url=api_url,
+            http_client=cancellable_http_client(),
         )
     if provider == "atlascloud":
         from row_bot.providers.transports.openai_compatible import ChatOpenAICompatible

--- a/src/row_bot/providers/transports/cancellable_http.py
+++ b/src/row_bot/providers/transports/cancellable_http.py
@@ -1,0 +1,41 @@
+"""httpx client that lets an active CancellationScope abort in-flight requests.
+
+Row-Bot's own transports (``openai_compatible.py``, ``codex_responses.py``,
+etc.) stream raw HTTP themselves and register the in-flight response with
+``current_cancellation_scope()`` so Stop can close a stalled connection.
+Chat models built directly from LangChain's ``ChatOpenAI``/``ChatAnthropic``/
+``ChatXAI`` delegate all networking to the underlying provider SDK, which
+gives Row-Bot no such hook by default -- a stalled stream on those models
+cannot be aborted by Stop and leaves the thread stuck "Thinking" until the
+app is restarted. Passing a client built here via the SDKs' ``http_client``
+constructor argument closes that gap without needing a custom transport.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from row_bot.cancellation import current_cancellation_scope
+
+
+def _register_response_with_active_scope(response: httpx.Response) -> None:
+    scope = current_cancellation_scope()
+    if scope is None:
+        return
+    close = getattr(response, "close", None)
+    if callable(close):
+        scope.register(close, "cancellable_http_client.response.close")
+
+
+def cancellable_http_client(**kwargs: object) -> httpx.Client:
+    """Build an ``httpx.Client`` whose responses can be closed by Stop.
+
+    Each response made through the returned client registers its ``close``
+    with whatever ``CancellationScope`` is active on the calling thread, so a
+    stalled read is aborted the same way Row-Bot's own streaming transports
+    already behave.
+    """
+
+    event_hooks = dict(kwargs.pop("event_hooks", None) or {})
+    event_hooks["response"] = [*event_hooks.get("response", []), _register_response_with_active_scope]
+    return httpx.Client(event_hooks=event_hooks, **kwargs)

--- a/tests/test_cancellable_http_client.py
+++ b/tests/test_cancellable_http_client.py
@@ -1,0 +1,91 @@
+import threading
+
+import httpx
+
+from row_bot.cancellation import CancellationScope, use_cancellation_scope
+from row_bot.providers.transports.cancellable_http import cancellable_http_client
+
+
+class _BlockingByteStream(httpx.SyncByteStream):
+    """A response body that blocks on read until told to close.
+
+    Mirrors a stalled network read from a real provider SDK: the reader is
+    parked past the point where it can observe cancellation until something
+    closes the underlying connection out from under it.
+    """
+
+    def __init__(self) -> None:
+        self.reading = threading.Event()
+        self.closed = threading.Event()
+        self.close_calls = 0
+
+    def __iter__(self):
+        self.reading.set()
+        assert self.closed.wait(timeout=1), "stream was never closed"
+        return iter(())
+
+    def close(self) -> None:
+        self.close_calls += 1
+        self.closed.set()
+
+
+def test_cancellable_http_client_closes_response_when_scope_is_cancelled():
+    stream = _BlockingByteStream()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream)
+
+    client = cancellable_http_client(transport=httpx.MockTransport(handler))
+    scope = CancellationScope()
+    result: dict[str, object] = {}
+
+    def consume() -> None:
+        with use_cancellation_scope(scope):
+            with client.stream("GET", "http://example.test/stream") as response:
+                result["status_code"] = response.status_code
+                list(response.iter_bytes())
+
+    worker = threading.Thread(target=consume)
+    worker.start()
+    assert stream.reading.wait(timeout=1)
+
+    scope.cancel("test")
+    worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    assert stream.close_calls == 1
+    assert result["status_code"] == 200
+
+
+def test_cancellable_http_client_no_active_scope_is_a_no_op():
+    stream = _BlockingByteStream()
+    stream.closed.set()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream)
+
+    client = cancellable_http_client(transport=httpx.MockTransport(handler))
+
+    with client.stream("GET", "http://example.test/stream") as response:
+        list(response.iter_bytes())
+
+    assert stream.close_calls == 1
+
+
+def test_cancellable_http_client_preserves_caller_event_hooks():
+    seen: list[str] = []
+
+    def custom_hook(response: httpx.Response) -> None:
+        seen.append("custom")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ok": True})
+
+    client = cancellable_http_client(
+        transport=httpx.MockTransport(handler),
+        event_hooks={"response": [custom_hook]},
+    )
+
+    client.get("http://example.test/ping")
+
+    assert seen == ["custom"]

--- a/tests/test_opencode_first_class_provider.py
+++ b/tests/test_opencode_first_class_provider.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import httpx
 import pytest
 
 import row_bot.models as models
@@ -507,6 +508,7 @@ def test_phase4_opencode_responses_runtime_keeps_v1_base_url(monkeypatch):
     assert model.kwargs["base_url"] == "https://opencode.ai/zen/v1"
     assert model.kwargs["use_responses_api"] is True
     assert model.kwargs["output_version"] == "responses/v1"
+    assert isinstance(model.kwargs["http_client"], httpx.Client)
 
 
 def test_phase4_opencode_anthropic_runtime_strips_v1(monkeypatch):
@@ -525,6 +527,7 @@ def test_phase4_opencode_anthropic_runtime_strips_v1(monkeypatch):
     assert model.kwargs["model"] == "minimax-m2.7"
     assert model.kwargs["api_key"] == "go-key"
     assert model.kwargs["base_url"] == "https://opencode.ai/zen/go"
+    assert isinstance(model.kwargs["http_client"], httpx.Client)
 
 
 def test_phase4_opencode_gemini_runtime_is_blocked(monkeypatch):

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -2,6 +2,7 @@ import sys
 import socket
 from types import ModuleType, SimpleNamespace
 
+import httpx
 import pytest
 
 import row_bot.providers.runtime as runtime
@@ -28,6 +29,7 @@ def test_openai_gpt5_family_uses_responses_api(monkeypatch):
     assert model.kwargs["model"] == "gpt-5.5-pro"
     assert model.kwargs["use_responses_api"] is True
     assert model.kwargs["output_version"] == "responses/v1"
+    assert isinstance(model.kwargs["http_client"], httpx.Client)
 
 
 def test_openai_legacy_chat_model_keeps_chat_completions_path(monkeypatch):
@@ -41,6 +43,7 @@ def test_openai_legacy_chat_model_keeps_chat_completions_path(monkeypatch):
 
     assert model.kwargs["model"] == "gpt-4o"
     assert "use_responses_api" not in model.kwargs
+    assert isinstance(model.kwargs["http_client"], httpx.Client)
 
 
 def test_anthropic_provider_constructor_is_preserved(monkeypatch):
@@ -58,6 +61,7 @@ def test_anthropic_provider_constructor_is_preserved(monkeypatch):
 
     assert model.kwargs["model"] == "claude-sonnet-4-5"
     assert model.kwargs["api_key"] == "anthropic-key"
+    assert isinstance(model.kwargs["http_client"], httpx.Client)
 
 
 def test_google_provider_constructor_is_preserved(monkeypatch):
@@ -92,6 +96,7 @@ def test_xai_provider_constructor_is_preserved(monkeypatch):
 
     assert model.kwargs["model"] == "grok-4"
     assert model.kwargs["api_key"] == "xai-key"
+    assert isinstance(model.kwargs["http_client"], httpx.Client)
 
 
 def test_openrouter_provider_constructor_is_preserved(monkeypatch):
@@ -737,6 +742,7 @@ def test_minimax_provider_creates_chat_anthropic_with_minimax_base_url(monkeypat
 
     assert model.kwargs["model"] == "MiniMax-M2.7"
     assert model.kwargs["api_key"] == "test-minimax-key"
+    assert isinstance(model.kwargs["http_client"], httpx.Client)
     assert model.kwargs["base_url"] == "https://api.minimax.io/anthropic"
 
 


### PR DESCRIPTION
## Summary

Fixes #145. Native OpenAI/Anthropic/xAI/MiniMax models are constructed straight
from LangChain's SDK wrappers (`ChatOpenAI`/`ChatAnthropic`/`ChatXAI`) with no
hook into Row-Bot's `CancellationScope`. Every other transport
(`openai_compatible`, `codex`, `claude_subscription`, `ollama_cloud`) already
registers the in-flight response's `close()` with the active scope so Stop can
abort a stalled read these construction sites never did.

When a stream on one of these providers stalls (e.g. right after a tool-call
approval resume reconnects), Stop flips `stop_event` but nothing closes the
blocked socket, so the producer thread never re-checks it and the thread stays
stuck "Thinking" until the app is restarted, exactly the repro in #145
(attach a file, cloud provider falls back to a gated vault search, deny/stop,
thread hangs forever).

`cancellable_http_client()` (new `providers/transports/cancellable_http.py`)
is an `httpx.Client` whose `event_hooks["response"]` registers each response's
`close` with `current_cancellation_scope()`, mirroring the pattern already
used by the custom transports. Passed as `http_client=` to all 7 raw
`ChatOpenAI`/`ChatAnthropic`/`ChatXAI` construction sites in `runtime.py`
(openai, anthropic, xai, minimax, and the opencode/custom-endpoint
`openai_responses`/`anthropic_messages` variants). `google` (different SDK,
no httpx client hook) is out of scope here.

## Type of change

- [x] Bug fix

## Risk area

- [x] Agent / prompts / tools

## Testing

- [ ] I ran `uv run python scripts/run_test_matrix.py fast`
- [ ] I ran `uv run python scripts/run_test_matrix.py pr` for shared, release-sensitive, or cross-subsystem changes
- [x] I added or updated tests
- [ ] I updated the relevant inventory in `tests/helpers/` when changing coverage ownership
- [ ] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

New `tests/test_cancellable_http_client.py` proves cancelling an active
`CancellationScope` closes a blocked streaming response through a real
`httpx.Client` (via `httpx.MockTransport`), plus assertions added to
`tests/test_provider_runtime.py` and `tests/test_opencode_first_class_provider.py`
confirming every affected construction site now passes `http_client`. Ran the
touched suites directly with pytest (no live provider keys), could not run
the project's `uv`-based test matrix in this environment; would appreciate
maintainer CI confirming the full matrix.

## Release notes

- [x] User-visible change, release notes needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant